### PR TITLE
A FIX ON RX1 AND RX2 RECEIVE WINDOW DURATIONS

### DIFF
--- a/model/end-device-lora-mac.h
+++ b/model/end-device-lora-mac.h
@@ -463,9 +463,16 @@ TracedValue<uint8_t> m_requiredTx;
   Time m_receiveDelay2;
 
   /**
-   * The duration of a receive window.
+   * The duration of a receive window in number of symbols. This should be 
+   * converted to time based or the reception parameter used.
+   * 
+   * The downlink preamble transmitted by the gateways contains 8 symbols. 
+   * The receiver requires 5 symbols to detect the preamble and synchronize. 
+   * Therefore there must be a 5 symbols overlap between the receive window 
+   * and the transmitted preamble. 
+   * (Ref: Recommended SX1272/76 Settings for EU868 LoRaWAN Network Operation )
    */
-  Time m_receiveWindowDuration;
+  uint8_t m_receiveWindowDurationInSymbols;
 
   /**
    * The event of the closing the first receive window.


### PR DESCRIPTION
This fix substitutes the constant receive window duration for Rx1 and Rx2 windows with a duration that corresponds to the particular spreading factor and bandwidth they are configured with. This will improve the power consumption calculation as it will switch the transceiver to standby mode for the duration of the time that matches the receiver configuration. It also will increase the overlap between these windows and other transmissions near the receive window.

## Proposed Changes
  - "m_receiveWindowDuration" which represents the receive window duration in seconds is changed to "m_receiveWindowDurationInSymbols" which only represents the receive window duration in the number of symbols. 
  - The duration of the windows in seconds is then calculated based on the DR that they are configured with 
