### PR TITLE
Add 'lorawan-' to the example program names for running with waf

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Otherwise, if tests fail or crash, consider filing an issue.
 
 The module includes the following examples:
 
-- `simple-lorawan-network-example`
-- `complete-lorawan-network-example`
+- `simple-network-example`
+- `complete-network-example`
 - `network-server-example`
 
 Examples can be run via the `./waf --run example-name` command.


### PR DESCRIPTION
This pull request fixes issue #46 

## Proposed Changes

  - Remove `lorawan-` from the program name in usage examples in the readme to have the example names be: 
    - `complete-network-example`
    - `simple-network-example`
