### PR TITLE
Fix calculation of the nextTransmissionDelay for class A EDs

### DIFF
--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -19,6 +19,7 @@
  *         Martina Capuzzo <capuzzom@dei.unipd.it>
  *
  * Modified by: Peggy Anderson <peggy.anderson@usask.ca>
+ *              qiuyukang <b612n@qq.com>
  */
 
 #include "ns3/class-a-end-device-lorawan-mac.h"
@@ -449,17 +450,34 @@ ClassAEndDeviceLorawanMac::GetNextClassTransmissionDelay (Time waitingTime)
 {
   NS_LOG_FUNCTION_NOARGS ();
 
-  if (!m_closeFirstWindow.IsExpired () || !m_closeSecondWindow.IsExpired () || !m_secondReceiveWindow.IsExpired () )
+  // This is a new packet from APP, it can be sent until the end of the second recieve 
+  // window(if the second recieve window has not closed yet)
+  if (!m_retxParams.waitingAck)
     {
-      NS_LOG_WARN ("Attempting to send when there are receive windows:" <<
-                   " Transmission postponed.");
+      if (!m_closeFirstWindow.IsExpired () || !m_closeSecondWindow.IsExpired () || !m_secondReceiveWindow.IsExpired () )
+        {
+          NS_LOG_WARN ("Attempting to send when there are receive windows:" <<
+                       " Transmission postponed.");
+          // Calculate the duration of a single symbol for the second receive window DR
+          double tSym = pow (2, GetSfFromDataRate (GetSecondReceiveWindowDataRate ())) / GetBandwidthFromDataRate ( GetSecondReceiveWindowDataRate ());
+          // Calculates the closing time of the second receive window
+          Time endSecondRxWindow = Time(m_secondReceiveWindow.GetTs()) + Seconds (m_receiveWindowDurationInSymbols*tSym);
 
-      // Calculate the duration of a single symbol for the second receive window DR
-      double tSym = pow (2, GetSfFromDataRate (GetSecondReceiveWindowDataRate ())) / GetBandwidthFromDataRate ( GetSecondReceiveWindowDataRate ());
-      // Calculates the closing time of the second receive window
-      Time endSecondRxWindow = Time(m_secondReceiveWindow.GetTs()) + Seconds (m_receiveWindowDurationInSymbols*tSym);
+          NS_LOG_DEBUG("Duration until endSecondRxWindow for new transmission:" << (endSecondRxWindow - Simulator::Now()).GetSeconds());
+          waitingTime = std::max (waitingTime, endSecondRxWindow - Simulator::Now());
+        }
+    }
+  // This is a retransmitted packet, it can be sent until the end of ACK_TIMEOUT (this 
+  // timer starts when the second recieve window was open)
+  else
+    {
+      double ack_timeout = m_uniformRV->GetValue (1,3);
+      // Calculates the duration until ACK_TIMEOUT (It may be a negative number, but it doesn't matter.)
+      Time retransmitWaitingTime = Time(m_secondReceiveWindow.GetTs()) - Simulator::Now() + Seconds (ack_timeout);
 
-      waitingTime = std::max (waitingTime, endSecondRxWindow - Simulator::Now());
+      NS_LOG_DEBUG("ack_timeout:" << ack_timeout << 
+                   " retransmitWaitingTime:" << retransmitWaitingTime.GetSeconds());
+      waitingTime = std::max (waitingTime, retransmitWaitingTime);
     }
 
   return waitingTime;

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -168,11 +168,11 @@ EndDeviceLorawanMac::Send (Ptr<Packet> packet)
   if (netxTxDelay != Seconds (0))
     {
       // Add the ACK_TIMEOUT random delay if it is a retransmission.
-      if (m_retxParams.waitingAck)
-        {
-          double ack_timeout = m_uniformRV->GetValue (1,3);
-          netxTxDelay = netxTxDelay + Seconds (ack_timeout);
-        }
+      // if (m_retxParams.waitingAck)
+      //   {
+      //     double ack_timeout = m_uniformRV->GetValue (1,3);
+      //     netxTxDelay = netxTxDelay + Seconds (ack_timeout);
+      //   }
       postponeTransmission (netxTxDelay, packet);
       return;
     }

--- a/model/end-device-lorawan-mac.h
+++ b/model/end-device-lorawan-mac.h
@@ -414,6 +414,12 @@ protected:
    */
   struct LoraRetxParameters m_retxParams;
 
+  /**
+   * An uniform random variable, used by the Shuffle method to randomly reorder
+   * the channel list.
+   */
+  Ptr<UniformRandomVariable> m_uniformRV;
+
   /////////////////
   //  Callbacks  //
   /////////////////
@@ -437,12 +443,6 @@ private:
    * Find the minimum waiting time before the next possible transmission.
    */
   Time GetNextTransmissionDelay (void);
-
-  /**
-   * An uniform random variable, used by the Shuffle method to randomly reorder
-   * the channel list.
-   */
-  Ptr<UniformRandomVariable> m_uniformRV;
 
   /**
    * Whether this device's data rate should be controlled by the NS.


### PR DESCRIPTION
Class A end device should resend the frame which is unacknowledged at least ACK_TIMEOUT seconds after the second reception window is opened.

This pull request fixes issue #77 

## Proposed Changes

  - For a retransmission frame, we compute the maximum between (first moment we are allowed to transmit according to duty cycle) and (startRxWindow2 + ACK_TIMEOUT) as a delay.
  - Checke out [LoRaWAN® Specification v1.1](https://lora-alliance.org/sites/default/files/2018-04/lorawantm_specification_-v1.1.pdf)  section 19.1 for more information.
