### PR TITLE
Fix a compilation error

### DIFF
--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -68,7 +68,7 @@ GatewayLorawanMac::Send (Ptr<Packet> packet)
   packet->AddPacketTag (tag);
 
   // Make sure we can transmit this packet
-  if (m_channelHelper.GetWaitingTime(CreateObject<LogicalLoraChannel> (frequency)) > 0)
+  if (m_channelHelper.GetWaitingTime(CreateObject<LogicalLoraChannel> (frequency)) > Time(0))
     {
       // We cannot send now!
       NS_LOG_WARN ("Trying to send a packet but Duty Cycle won't allow it. Aborting.");

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -848,9 +848,9 @@ LogicalLoraChannelTest::DoRun (void)
                          "Waiting time doesn't behave as expected");
 
   // Other bands are not affected by this transmission
-  NS_TEST_EXPECT_MSG_EQ (channelHelper->GetWaitingTime (channel4), 0,
+  NS_TEST_EXPECT_MSG_EQ (channelHelper->GetWaitingTime (channel4), Time (0),
                          "Waiting time affects other subbands");
-  NS_TEST_EXPECT_MSG_EQ (channelHelper->GetWaitingTime (channel5), 0,
+  NS_TEST_EXPECT_MSG_EQ (channelHelper->GetWaitingTime (channel5), Time (0),
                          "Waiting time affects other subbands");
 }
 


### PR DESCRIPTION
This pull request fixes issue #89

## Proposed Changes

  - Change `0` to `Time (0)` when comparing `ns3::Time` with `0`.
