### PR TITLE
Improving NbTrans support for class A

### DIFF
--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -35,17 +35,19 @@ using namespace lorawan;
 NS_LOG_COMPONENT_DEFINE ("ComplexLorawanNetworkExample");
 
 // Network settings
-int nDevices = 200;
+int nDevices = 120;
 int nGateways = 1;
-double radius = 6400; //Note that due to model updates, 7500 m is no longer the maximum distance 
-double simulationTime = 600;
+double radius = 6300; //Note that due to model updates, 7500 m is no longer the maximum distance 
+double simulationTime = 591*50;
 
 // Channel model
 bool realisticChannelModel = false;
 
-int appPeriodSeconds = 600;
+int confirmedPercentage = 15; 
 
-int numberOfTransmissions = 1; // The maximum number of transmissions allowed, valid is [1:15]
+int appPeriodSeconds = 591;
+
+int numberOfTransmissions = 3; // The maximum number of transmissions allowed, valid is [1:15]
 
 // Output control
 bool print = true;
@@ -190,6 +192,11 @@ main (int argc, char *argv[])
 
   // Now end devices are connected to the channel
 
+  // Figure out how many devices should employ confirmed traffic
+  int confirmedNumber = confirmedPercentage * endDevices.GetN () / 100;
+  int i = 0;
+
+
   // Connect trace sources
   for (NodeContainer::Iterator j = endDevices.Begin (); j != endDevices.End (); ++j)
     {
@@ -197,9 +204,16 @@ main (int argc, char *argv[])
       Ptr<LoraNetDevice> loraNetDevice = node->GetDevice (0)->GetObject<LoraNetDevice> ();
       Ptr<LoraPhy> phy = loraNetDevice->GetPhy ();
 
+
       Ptr<LorawanMac> edMac = loraNetDevice->GetMac ();
       Ptr<ClassAEndDeviceLorawanMac> edLorawanMac = edMac->GetObject<ClassAEndDeviceLorawanMac> ();
       edLorawanMac->SetMaxNumberOfTransmissions (numberOfTransmissions);
+
+            // Set message type, otherwise the NS does not send ACKs
+      if (i < confirmedNumber)
+      {
+       edLorawanMac->SetMType (LorawanMacHeader::CONFIRMED_DATA_UP);
+      }
     }
 
   /*********************

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -45,6 +45,8 @@ bool realisticChannelModel = false;
 
 int appPeriodSeconds = 600;
 
+uint8_t numberOfTransmissions = 1; // The maximum number of transmissions allowed, valid is [1:15]
+
 // Output control
 bool print = true;
 
@@ -87,6 +89,10 @@ main (int argc, char *argv[])
   // LogComponentEnable("NetworkStatus", LOG_LEVEL_ALL);
   // LogComponentEnable("NetworkController", LOG_LEVEL_ALL);
 
+  LogComponentEnableAll (LOG_PREFIX_FUNC);
+  LogComponentEnableAll (LOG_PREFIX_NODE);
+  LogComponentEnableAll (LOG_PREFIX_TIME);
+  
   /***********
    *  Setup  *
    ***********/
@@ -190,6 +196,10 @@ main (int argc, char *argv[])
       Ptr<Node> node = *j;
       Ptr<LoraNetDevice> loraNetDevice = node->GetDevice (0)->GetObject<LoraNetDevice> ();
       Ptr<LoraPhy> phy = loraNetDevice->GetPhy ();
+
+      Ptr<LorawanMac> edMac = loraNetDevice->GetMac ();
+      Ptr<ClassAEndDeviceLorawanMac> edLorawanMac = edMac->GetObject<ClassAEndDeviceLorawanMac> ();
+      edLorawanMac->SetMaxNumberOfTransmissions (numberOfTransmissions);
     }
 
   /*********************

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -45,7 +45,7 @@ bool realisticChannelModel = false;
 
 int appPeriodSeconds = 600;
 
-uint8_t numberOfTransmissions = 1; // The maximum number of transmissions allowed, valid is [1:15]
+int numberOfTransmissions = 1; // The maximum number of transmissions allowed, valid is [1:15]
 
 // Output control
 bool print = true;

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -35,19 +35,17 @@ using namespace lorawan;
 NS_LOG_COMPONENT_DEFINE ("ComplexLorawanNetworkExample");
 
 // Network settings
-int nDevices = 120;
+int nDevices = 200;
 int nGateways = 1;
-double radius = 6300; //Note that due to model updates, 7500 m is no longer the maximum distance 
-double simulationTime = 591*50;
+double radius = 6400; //Note that due to model updates, 7500 m is no longer the maximum distance 
+double simulationTime = 600;
 
 // Channel model
 bool realisticChannelModel = false;
 
-int confirmedPercentage = 15; 
+int appPeriodSeconds = 600;
 
-int appPeriodSeconds = 591;
-
-int numberOfTransmissions = 3; // The maximum number of transmissions allowed, valid is [1:15]
+int numberOfTransmissions = 1; // The maximum number of transmissions allowed, valid is [1:15]
 
 // Output control
 bool print = true;
@@ -192,11 +190,6 @@ main (int argc, char *argv[])
 
   // Now end devices are connected to the channel
 
-  // Figure out how many devices should employ confirmed traffic
-  int confirmedNumber = confirmedPercentage * endDevices.GetN () / 100;
-  int i = 0;
-
-
   // Connect trace sources
   for (NodeContainer::Iterator j = endDevices.Begin (); j != endDevices.End (); ++j)
     {
@@ -204,16 +197,9 @@ main (int argc, char *argv[])
       Ptr<LoraNetDevice> loraNetDevice = node->GetDevice (0)->GetObject<LoraNetDevice> ();
       Ptr<LoraPhy> phy = loraNetDevice->GetPhy ();
 
-
       Ptr<LorawanMac> edMac = loraNetDevice->GetMac ();
       Ptr<ClassAEndDeviceLorawanMac> edLorawanMac = edMac->GetObject<ClassAEndDeviceLorawanMac> ();
       edLorawanMac->SetMaxNumberOfTransmissions (numberOfTransmissions);
-
-            // Set message type, otherwise the NS does not send ACKs
-      if (i < confirmedNumber)
-      {
-       edLorawanMac->SetMType (LorawanMacHeader::CONFIRMED_DATA_UP);
-      }
     }
 
   /*********************

--- a/helper/lora-packet-tracker.cc
+++ b/helper/lora-packet-tracker.cc
@@ -137,35 +137,7 @@ LoraPacketTracker::PacketReceptionCallback (Ptr<Packet const> packet, uint32_t g
                                  << " was successfully received at gateway "
                                  << gwId);
 
-
-      if(m_packetTracker.count(packet) == 1) //first reception
-        {
-          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           RECEIVED)); 
-        }
-      else
-        {
-          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
-          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
-          
-          int i = 1;
-
-          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
-          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
-            {
-                    
-              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
-              {
-                NS_LOG_DEBUG("This is copy  " << i <<" of packet "<< packet);                
-                NS_LOG_DEBUG("This packet was sent at " << (*it).second.sendTime);
-                NS_LOG_DEBUG("It was not yet received by GW " << gwId << " logging it now as RECEIVED.");
-                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           RECEIVED)); 
-              }
-              i++;           
-            }
-        }
+      SetPacketOutcome(packet, std::pair<int, enum PhyPacketOutcome> (gwId,RECEIVED));
     }
 }
 
@@ -178,34 +150,7 @@ LoraPacketTracker::InterferenceCallback (Ptr<Packet const> packet, uint32_t gwId
                                  << " was interfered at gateway "
                                  << gwId);
 
-      if(m_packetTracker.count(packet) == 1) //first reception
-        {
-          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           INTERFERED)); 
-        }
-      else
-        {
-          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
-          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
-          
-          int i = 1;
-
-          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
-          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
-            {
-                    
-              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
-              {
-                NS_LOG_INFO("This is copy  " << i <<" of packet "<< packet);                
-                NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
-                NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now as INTERFERED.");
-                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           INTERFERED)); 
-              }
-              i++;           
-            }
-        }
+      SetPacketOutcome(packet, std::pair<int, enum PhyPacketOutcome> (gwId,INTERFERED));
     }
 }
 
@@ -218,34 +163,7 @@ LoraPacketTracker::NoMoreReceiversCallback (Ptr<Packet const> packet, uint32_t g
                                  << " was lost because no more receivers at gateway "
                                  << gwId);
 
-      if(m_packetTracker.count(packet) == 1) //first reception
-        {
-          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           NO_MORE_RECEIVERS)); 
-        }
-      else
-        {
-          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
-          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
-          
-          int i = 1;
-
-          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
-          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
-            {
-                    
-              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
-              {
-                NS_LOG_INFO("This is copy  " << i <<" of packet "<< packet);                
-                NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
-                NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now as NO_MORE_RECEIVERS.");
-                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           NO_MORE_RECEIVERS)); 
-              }
-              i++;           
-            }
-        }                                                                     
+      SetPacketOutcome(packet, std::pair<int, enum PhyPacketOutcome> (gwId,NO_MORE_RECEIVERS));                                                                      
     }
 }
 
@@ -258,34 +176,7 @@ LoraPacketTracker::UnderSensitivityCallback (Ptr<Packet const> packet, uint32_t 
                                  << " was lost because under sensitivity at gateway "
                                  << gwId);
 
-      if(m_packetTracker.count(packet) == 1) //first reception
-        {
-          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           UNDER_SENSITIVITY)); 
-        }
-      else
-        {
-          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
-          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
-          
-          int i = 1;
-
-          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
-          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
-            {
-                    
-              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
-              {
-                NS_LOG_INFO("This is copy  " << i <<" of packet "<< packet);                
-                NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
-                NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now as UNDER_SENSITIVITY.");
-                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           UNDER_SENSITIVITY)); 
-              }
-              i++;           
-            }
-        }    
+      SetPacketOutcome(packet, std::pair<int, enum PhyPacketOutcome> (gwId,UNDER_SENSITIVITY));                        
     }
 }
 
@@ -298,35 +189,44 @@ LoraPacketTracker::LostBecauseTxCallback (Ptr<Packet const> packet, uint32_t gwI
                                  << " was lost because of GW transmission at gateway "
                                  << gwId);
 
-      if(m_packetTracker.count(packet) == 1) //first reception
-        {
-          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           LOST_BECAUSE_TX)); 
-        }
-      else
-        {
-          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
-          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
-          
-          int i = 1;
-
-          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
-          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
-            {
-                    
-              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
-              {
-                NS_LOG_INFO("This is copy  " << i <<" of packet "<< packet);                
-                NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
-                NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now as LOST_BECAUSE_TX.");
-                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           LOST_BECAUSE_TX)); 
-              }
-              i++;           
-            }
-        }    
+      SetPacketOutcome(packet, std::pair<int, enum PhyPacketOutcome> (gwId, LOST_BECAUSE_TX));   
     }
+}
+
+void
+LoraPacketTracker::SetPacketOutcome(Ptr<Packet const> packet, std::pair<int, enum PhyPacketOutcome> outcome)
+{
+    NS_LOG_FUNCTION (this);
+
+    uint32_t gwId = outcome.first;
+
+    if(m_packetTracker.count(packet) == 1) //first reception
+      {
+        std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
+        (*it).second.outcomes.insert (outcome); 
+      }
+    else
+      {
+        std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
+        ret = m_packetTracker.equal_range(packet); // find all instances of received packet
+        
+        int i = 1;
+
+        //loop through all instances and find the one which doesn't yet have an outcome at this gateway
+        for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
+          {
+                  
+            if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
+            {
+              NS_LOG_INFO("This is copy " << i <<" of packet "<< packet);                
+              NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
+              NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now with outcome " << outcome.second);
+              (*it).second.outcomes.insert(outcome); 
+            }
+            i++;           
+          }
+      } 
+
 }
 
 bool

--- a/helper/lora-packet-tracker.cc
+++ b/helper/lora-packet-tracker.cc
@@ -137,9 +137,35 @@ LoraPacketTracker::PacketReceptionCallback (Ptr<Packet const> packet, uint32_t g
                                  << " was successfully received at gateway "
                                  << gwId);
 
-      std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-      (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           RECEIVED));
+
+      if(m_packetTracker.count(packet) == 1) //first reception
+        {
+          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
+          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           RECEIVED)); 
+        }
+      else
+        {
+          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
+          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
+          
+          int i = 1;
+
+          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
+          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
+            {
+                    
+              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
+              {
+                NS_LOG_DEBUG("This is copy  " << i <<" of packet "<< packet);                
+                NS_LOG_DEBUG("This packet was sent at " << (*it).second.sendTime);
+                NS_LOG_DEBUG("It was not yet received by GW " << gwId << " logging it now as RECEIVED.");
+                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           RECEIVED)); 
+              }
+              i++;           
+            }
+        }
     }
 }
 
@@ -152,9 +178,34 @@ LoraPacketTracker::InterferenceCallback (Ptr<Packet const> packet, uint32_t gwId
                                  << " was interfered at gateway "
                                  << gwId);
 
-      std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-      (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           INTERFERED));
+      if(m_packetTracker.count(packet) == 1) //first reception
+        {
+          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
+          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           INTERFERED)); 
+        }
+      else
+        {
+          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
+          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
+          
+          int i = 1;
+
+          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
+          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
+            {
+                    
+              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
+              {
+                NS_LOG_INFO("This is copy  " << i <<" of packet "<< packet);                
+                NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
+                NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now as INTERFERED.");
+                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           INTERFERED)); 
+              }
+              i++;           
+            }
+        }
     }
 }
 
@@ -166,9 +217,35 @@ LoraPacketTracker::NoMoreReceiversCallback (Ptr<Packet const> packet, uint32_t g
       NS_LOG_INFO ("PHY packet " << packet
                                  << " was lost because no more receivers at gateway "
                                  << gwId);
-      std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-      (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           NO_MORE_RECEIVERS));
+
+      if(m_packetTracker.count(packet) == 1) //first reception
+        {
+          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
+          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           NO_MORE_RECEIVERS)); 
+        }
+      else
+        {
+          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
+          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
+          
+          int i = 1;
+
+          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
+          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
+            {
+                    
+              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
+              {
+                NS_LOG_INFO("This is copy  " << i <<" of packet "<< packet);                
+                NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
+                NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now as NO_MORE_RECEIVERS.");
+                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           NO_MORE_RECEIVERS)); 
+              }
+              i++;           
+            }
+        }                                                                     
     }
 }
 
@@ -181,9 +258,34 @@ LoraPacketTracker::UnderSensitivityCallback (Ptr<Packet const> packet, uint32_t 
                                  << " was lost because under sensitivity at gateway "
                                  << gwId);
 
-      std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-      (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           UNDER_SENSITIVITY));
+      if(m_packetTracker.count(packet) == 1) //first reception
+        {
+          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
+          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           UNDER_SENSITIVITY)); 
+        }
+      else
+        {
+          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
+          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
+          
+          int i = 1;
+
+          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
+          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
+            {
+                    
+              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
+              {
+                NS_LOG_INFO("This is copy  " << i <<" of packet "<< packet);                
+                NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
+                NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now as UNDER_SENSITIVITY.");
+                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           UNDER_SENSITIVITY)); 
+              }
+              i++;           
+            }
+        }    
     }
 }
 
@@ -196,9 +298,34 @@ LoraPacketTracker::LostBecauseTxCallback (Ptr<Packet const> packet, uint32_t gwI
                                  << " was lost because of GW transmission at gateway "
                                  << gwId);
 
-      std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
-      (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
-                                                                           LOST_BECAUSE_TX));
+      if(m_packetTracker.count(packet) == 1) //first reception
+        {
+          std::map<Ptr<Packet const>, PacketStatus>::iterator it = m_packetTracker.find (packet);
+          (*it).second.outcomes.insert (std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           LOST_BECAUSE_TX)); 
+        }
+      else
+        {
+          std::pair <std::multimap<Ptr<Packet const>, PacketStatus>::iterator, std::multimap<Ptr<Packet const>, PacketStatus>::iterator> ret;
+          ret = m_packetTracker.equal_range(packet); // find all instances of received packet
+          
+          int i = 1;
+
+          //loop through all instances and find the one which doesn't yet have an outcome at this gateway
+          for(std::multimap<Ptr<Packet const>, PacketStatus>::iterator it=ret.first; it != ret.second; ++it)
+            {
+                    
+              if((*it).second.outcomes.find(gwId) == (*it).second.outcomes.end()) 
+              {
+                NS_LOG_INFO("This is copy  " << i <<" of packet "<< packet);                
+                NS_LOG_INFO("This packet was sent at " << (*it).second.sendTime);
+                NS_LOG_INFO("It was not yet received by GW " << gwId << " logging it now as LOST_BECAUSE_TX.");
+                (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome> (gwId,
+                                                                           LOST_BECAUSE_TX)); 
+              }
+              i++;           
+            }
+        }    
     }
 }
 
@@ -300,6 +427,9 @@ LoraPacketTracker::PrintPhyPacketsPerGw (Time startTime, Time stopTime,
           NS_LOG_DEBUG ("Dealing with packet " << (*itPhy).second.packet);
           NS_LOG_DEBUG ("This packet was received by " <<
                         (*itPhy).second.outcomes.size () << " gateways");
+
+          if((*itPhy).second.outcomes.find(gwId) != (*itPhy).second.outcomes.end()) 
+            NS_LOG_DEBUG ("Packet outcome:" << (*itPhy).second.outcomes.at(gwId));
 
           if ((*itPhy).second.outcomes.count (gwId) > 0)
             {

--- a/helper/lora-packet-tracker.h
+++ b/helper/lora-packet-tracker.h
@@ -66,7 +66,7 @@ struct RetransmissionStatus
 };
 
 typedef std::map<Ptr<Packet const>, MacPacketStatus> MacPacketData;
-typedef std::map<Ptr<Packet const>, PacketStatus> PhyPacketData;
+typedef std::multimap<Ptr<Packet const>, PacketStatus> PhyPacketData;
 typedef std::map<Ptr<Packet const>, RetransmissionStatus> RetransmissionData;
 
 

--- a/helper/lora-packet-tracker.h
+++ b/helper/lora-packet-tracker.h
@@ -107,6 +107,10 @@ public:
   //                            macPacketTracker, RetransmissionData reTransmissionTracker,
   //                            PhyPacketData packetTracker);
 
+  /* 
+  * Sets a packet's outcome at a specified gateway to one of PhyPacketOutcome's values. 
+  */
+  void SetPacketOutcome(Ptr<Packet const> packet, std::pair<int, enum PhyPacketOutcome> outcome);
   /**
    * Count packets to evaluate the performance at PHY level of a specific
    * gateway.

--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -195,13 +195,18 @@ ClassAEndDeviceLorawanMac::Receive (Ptr<Packet const> packet)
           // packet in the second receive window and finding out, after the
           // fact, that the packet is not for us. In either case, if we no
           // longer have any retransmissions left, we declare failure.
-          if (m_retxParams.waitingAck && m_secondReceiveWindow.IsExpired ())
+          if (m_secondReceiveWindow.IsExpired ())
             {
               if (m_retxParams.retxLeft == 0)
                 {
                   uint8_t txs = m_maxNumbTx - (m_retxParams.retxLeft);
-                  m_requiredTxCallback (txs, false, m_retxParams.firstAttempt, m_retxParams.packet);
-                  NS_LOG_DEBUG ("Failure: no more retransmissions left. Used " << unsigned(txs) << " transmissions.");
+                  if(m_retxParams.waitingAck)
+                    {
+                      m_requiredTxCallback (txs, false, m_retxParams.firstAttempt, m_retxParams.packet);
+                      NS_LOG_DEBUG ("Failure: no more retransmissions left for confirmed packet. Used " << unsigned(txs) << " transmissions.");
+                    }
+                  else if(m_retxParams.sendingMultipleUnconfirmed)
+                      NS_LOG_DEBUG ("Failure: no more retransmissions left for unconfirmed packet. Used " << unsigned(txs) << " transmissions.");
 
                   // Reset retransmission parameters
                   resetRetransmissionParameters ();
@@ -214,7 +219,7 @@ ClassAEndDeviceLorawanMac::Receive (Ptr<Packet const> packet)
             }
         }
     }
-  else if (m_retxParams.waitingAck && m_secondReceiveWindow.IsExpired ())
+  else if (m_secondReceiveWindow.IsExpired ())
     {
       NS_LOG_INFO ("The packet we are receiving is in uplink.");
       if (m_retxParams.retxLeft > 0)
@@ -225,8 +230,14 @@ ClassAEndDeviceLorawanMac::Receive (Ptr<Packet const> packet)
       else
         {
           uint8_t txs = m_maxNumbTx - (m_retxParams.retxLeft);
-          m_requiredTxCallback (txs, false, m_retxParams.firstAttempt, m_retxParams.packet);
-          NS_LOG_DEBUG ("Failure: no more retransmissions left. Used " << unsigned(txs) << " transmissions.");
+          if(m_retxParams.waitingAck)
+            {
+
+              m_requiredTxCallback (txs, false, m_retxParams.firstAttempt, m_retxParams.packet);
+              NS_LOG_DEBUG ("Failure: no more retransmissions left for confirmed packet. Used " << unsigned(txs) << " transmissions.");
+            }
+          else if (m_retxParams.sendingMultipleUnconfirmed)
+              NS_LOG_DEBUG ("Failure: no more retransmissions left for unconfirmed packet. Used " << unsigned(txs) << " transmissions.");
 
           // Reset retransmission parameters
           resetRetransmissionParameters ();
@@ -244,7 +255,7 @@ ClassAEndDeviceLorawanMac::FailedReception (Ptr<Packet const> packet)
   // Switch to sleep after a failed reception
   m_phy->GetObject<EndDeviceLoraPhy> ()->SwitchToSleep ();
 
-  if (m_secondReceiveWindow.IsExpired () && m_retxParams.waitingAck)
+  if (m_secondReceiveWindow.IsExpired ())
     {
       if (m_retxParams.retxLeft > 0)
         {
@@ -254,8 +265,15 @@ ClassAEndDeviceLorawanMac::FailedReception (Ptr<Packet const> packet)
       else
         {
           uint8_t txs = m_maxNumbTx - (m_retxParams.retxLeft);
-          m_requiredTxCallback (txs, false, m_retxParams.firstAttempt, m_retxParams.packet);
-          NS_LOG_DEBUG ("Failure: no more retransmissions left. Used " << unsigned(txs) << " transmissions.");
+          if( m_retxParams.waitingAck)
+            {
+
+              m_requiredTxCallback (txs, false, m_retxParams.firstAttempt, m_retxParams.packet);
+              NS_LOG_DEBUG ("Failure: no more retransmissions left for confirmed packet. Used " << unsigned(txs) << " transmissions.");              
+            }
+          else if(m_retxParams.sendingMultipleUnconfirmed)
+              NS_LOG_DEBUG ("Failure: no more retransmissions left for unconfirmed packet. Used " << unsigned(txs) << " transmissions.");
+
 
           // Reset retransmission parameters
           resetRetransmissionParameters ();
@@ -405,40 +423,42 @@ ClassAEndDeviceLorawanMac::CloseSecondReceiveWindow (void)
       break;
     }
 
-  if (m_retxParams.waitingAck)
-    {
-      NS_LOG_DEBUG ("No reception initiated by PHY: rescheduling transmission.");
-      if (m_retxParams.retxLeft > 0 )
-        {
-          NS_LOG_INFO ("We have " << unsigned(m_retxParams.retxLeft) << " retransmissions left: rescheduling transmission.");
-          this->Send (m_retxParams.packet);
-        }
 
-      else if (m_retxParams.retxLeft == 0 && m_phy->GetObject<EndDeviceLoraPhy> ()->GetState () != EndDeviceLoraPhy::RX)
-        {
-          uint8_t txs = m_maxNumbTx - (m_retxParams.retxLeft);
-          m_requiredTxCallback (txs, false, m_retxParams.firstAttempt, m_retxParams.packet);
-          NS_LOG_DEBUG ("Failure: no more retransmissions left. Used " << unsigned(txs) << " transmissions.");
 
-          // Reset retransmission parameters
-          resetRetransmissionParameters ();
-        }
+    if (m_retxParams.retxLeft > 0 )
+      {
+        if(m_retxParams.waitingAck)
+           NS_LOG_DEBUG ("No reception initiated by PHY: rescheduling transmission of confirmed packet.");
 
-      else
-        {
-          NS_ABORT_MSG ("The number of retransmissions left is negative ! ");
-        }
-    }
-  else
-    {
-      uint8_t txs = m_maxNumbTx - (m_retxParams.retxLeft );
-      m_requiredTxCallback (txs, true, m_retxParams.firstAttempt, m_retxParams.packet);
-      NS_LOG_INFO ("We have " << unsigned(m_retxParams.retxLeft) <<
-                   " transmissions left. We were not transmitting confirmed messages.");
+        if(m_retxParams.sendingMultipleUnconfirmed)
+           NS_LOG_DEBUG ("No reception initiated by PHY: rescheduling transmission of unconfirmed packet.");     
+           
+        NS_LOG_INFO ("We have " << unsigned(m_retxParams.retxLeft) << " retransmissions left: rescheduling transmission.");
 
-      // Reset retransmission parameters
-      resetRetransmissionParameters ();
-    }
+        this->Send (m_retxParams.packet);
+      }
+
+    else if (m_retxParams.retxLeft == 0 && m_phy->GetObject<EndDeviceLoraPhy> ()->GetState () != EndDeviceLoraPhy::RX)
+      {
+        
+        uint8_t txs = m_maxNumbTx - (m_retxParams.retxLeft);
+        if(m_retxParams.waitingAck)
+          {
+
+            m_requiredTxCallback (txs, false, m_retxParams.firstAttempt, m_retxParams.packet);
+            NS_LOG_DEBUG ("Failure: no more retransmissions left for confirmed packet. Used " << unsigned(txs) << " transmissions.");
+          }
+        else if (m_retxParams.sendingMultipleUnconfirmed)
+            NS_LOG_DEBUG ("Finished: no more retransmissions left for unconfirmed packet. Used " << unsigned(txs) << " transmissions.");
+
+        // Reset retransmission parameters
+        resetRetransmissionParameters ();
+      }
+
+    else
+      {
+        NS_ABORT_MSG ("The number of retransmissions left is negative ! ");
+      }
 }
 
 /////////////////////////

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -89,7 +89,7 @@ EndDeviceLorawanMac::GetTypeId (void)
                    "Maximum number of transmissions for a packet",
                    IntegerValue (1),
                    MakeIntegerAccessor (&EndDeviceLorawanMac::m_maxNumbTx),
-                   MakeIntegerChecker<uint8_t> ())
+                   MakeIntegerChecker<uint8_t> (1, 15))
     .AddAttribute ("EnableEDDataRateAdaptation",
                    "Whether the End Device should up its Data Rate "
                    "in case it doesn't get a reply from the NS.",

--- a/model/end-device-lorawan-mac.h
+++ b/model/end-device-lorawan-mac.h
@@ -341,6 +341,7 @@ protected:
     Time firstAttempt;
     Ptr<Packet> packet = 0;
     bool waitingAck = false;
+    bool sendingMultipleUnconfirmed = false;
     uint8_t retxLeft;
   };
 


### PR DESCRIPTION
This request improves NbTrans support by causing both unconfirmed and confirmed traffic to be transmitting NbTrans times.

This code was written for class A devices and whilst NbTrans is supported fully the LinkADRReq command does not update NbTrans. I assumed that most people aren't using ADR and those that do would have noticed that this command never supported NbTrans updates and would have implemented it themselves if required.

Furthermore, the code doesn't test if you provided a NbTrans value between 1 and 15. It will simply attempt to transmit the packet's the provided number of times.

This pull request fixes issues #110 and #112 

## Proposed Changes

  - LoraRetxParameters struct now has an additional boolean value sendingMultipleUnconfirmed. 
  - PhyPacketData is now a multimap to allow for the storage of duplicate packets. Each packet's PHY result is now saved and thus PrintPhyPacketsPerGw() will now indicate what happened to all of the transmitted packets.
  -  The default number of transmissions have been changed to the protocol's stated 1 instead of the current 8.
