### PR TITLE
Fix null check in PeriodicSender

### DIFF
--- a/model/periodic-sender.cc
+++ b/model/periodic-sender.cc
@@ -135,7 +135,7 @@ PeriodicSender::StartApplication(void)
     NS_LOG_FUNCTION(this);
 
     // Make sure we have a MAC layer
-    if (m_mac)
+    if (!m_mac)
     {
         // Assumes there's only one device
         Ptr<LoraNetDevice> loraNetDevice = m_node->GetDevice(0)->GetObject<LoraNetDevice>();


### PR DESCRIPTION
Null pointer dereference caused by a refactor in a82f2cc45d00f368991b2f4eb8706abd84e246c0
