### PR TITLE
Fix doxygen errors in the module

### DIFF
--- a/examples/adr-example.cc
+++ b/examples/adr-example.cc
@@ -59,7 +59,7 @@ main(int argc, char* argv[])
     double maxSpeed = 16;
     std::string adrType = "ns3::AdrComponent";
 
-    CommandLine cmd;
+    CommandLine cmd(__FILE__);
     cmd.AddValue("verbose", "Whether to print output or not", verbose);
     cmd.AddValue("MultipleGwCombiningMethod", "ns3::AdrComponent::MultipleGwCombiningMethod");
     cmd.AddValue("MultiplePacketsCombiningMethod",

--- a/examples/aloha-throughput.cc
+++ b/examples/aloha-throughput.cc
@@ -70,7 +70,7 @@ main(int argc, char* argv[])
 {
     std::string interferenceMatrix = "aloha";
 
-    CommandLine cmd;
+    CommandLine cmd(__FILE__);
     cmd.AddValue("nDevices", "Number of end devices to include in the simulation", nDevices);
     cmd.AddValue("simulationTime", "Simulation Time", simulationTime);
     cmd.AddValue("interferenceMatrix",

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -52,7 +52,7 @@ bool print = true;
 int
 main(int argc, char* argv[])
 {
-    CommandLine cmd;
+    CommandLine cmd(__FILE__);
     cmd.AddValue("nDevices", "Number of end devices to include in the simulation", nDevices);
     cmd.AddValue("radius", "The radius of the area to simulate", radius);
     cmd.AddValue("simulationTime", "The time for which to simulate", simulationTime);

--- a/examples/frame-counter-update.cc
+++ b/examples/frame-counter-update.cc
@@ -90,7 +90,7 @@ ChangeEndDevicePosition(Ptr<Node> endDevice, bool inRange)
 int
 main(int argc, char* argv[])
 {
-    CommandLine cmd;
+    CommandLine cmd(__FILE__);
     cmd.AddValue("simulationTime", "The time for which to simulate", simulationTime);
     cmd.AddValue("MaxTransmissions", "ns3::EndDeviceLorawanMac::MaxTransmissions");
     cmd.AddValue("MType", "ns3::EndDeviceLorawanMac::MType");

--- a/examples/network-server-example.cc
+++ b/examples/network-server-example.cc
@@ -33,7 +33,7 @@ main(int argc, char* argv[])
 {
     bool verbose = false;
 
-    CommandLine cmd;
+    CommandLine cmd(__FILE__);
     cmd.AddValue("verbose", "Whether to print output or not", verbose);
     cmd.Parse(argc, argv);
 

--- a/model/network-controller.cc
+++ b/model/network-controller.cc
@@ -32,6 +32,7 @@ TypeId
 NetworkController::GetTypeId(void)
 {
     static TypeId tid = TypeId("ns3::NetworkController")
+                            .SetParent<Object>()
                             .AddConstructor<NetworkController>()
                             .SetGroupName("lorawan");
     return tid;

--- a/model/network-status.cc
+++ b/model/network-status.cc
@@ -42,8 +42,10 @@ NS_OBJECT_ENSURE_REGISTERED(NetworkStatus);
 TypeId
 NetworkStatus::GetTypeId(void)
 {
-    static TypeId tid =
-        TypeId("ns3::NetworkStatus").AddConstructor<NetworkStatus>().SetGroupName("lorawan");
+    static TypeId tid = TypeId("ns3::NetworkStatus")
+                            .SetParent<Object>()
+                            .AddConstructor<NetworkStatus>()
+                            .SetGroupName("lorawan");
     return tid;
 }
 


### PR DESCRIPTION
Fix problems causing errors when building doxygen:
- Add parent declaration for TypeId of all classes
- Add \_\_FILE\_\_ param to CommandLine constructor in examples

Now running `./ns3 docs doxygen` will not fail.