### PR TITLE
Apply .clang-tidy linting rules to all files

### DIFF
--- a/examples/adr-example.cc
+++ b/examples/adr-example.cc
@@ -138,7 +138,8 @@ main(int argc, char* argv[])
     //////////
 
     // End Device mobility
-    MobilityHelper mobilityEd, mobilityGw;
+    MobilityHelper mobilityEd;
+    MobilityHelper mobilityGw;
     mobilityEd.SetPositionAllocator(
         "ns3::RandomRectanglePositionAllocator",
         "X",
@@ -242,7 +243,7 @@ main(int argc, char* argv[])
     // Do not set spreading factors up: we will wait for the NS to do this
     if (initializeSF)
     {
-        macHelper.SetSpreadingFactorsUp(endDevices, gateways, channel);
+        LorawanMacHelper::SetSpreadingFactorsUp(endDevices, gateways, channel);
     }
 
     ////////////

--- a/examples/aloha-throughput.cc
+++ b/examples/aloha-throughput.cc
@@ -173,7 +173,7 @@ main(int argc, char* argv[])
     mobility.Install(endDevices);
 
     // Make it so that nodes are at a certain height > 0
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<MobilityModel> mobility = (*j)->GetObject<MobilityModel>();
         Vector position = mobility->GetPosition();
@@ -196,7 +196,7 @@ main(int argc, char* argv[])
     // Now end devices are connected to the channel
 
     // Connect trace sources
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> node = *j;
         Ptr<LoraNetDevice> loraNetDevice = node->GetDevice(0)->GetObject<LoraNetDevice>();
@@ -245,26 +245,25 @@ main(int argc, char* argv[])
     {
         LoraTxParameters txParams;
         txParams.sf = sf;
-        txParams.headerDisabled = 0;
+        txParams.headerDisabled = false;
         txParams.codingRate = 1;
         txParams.bandwidthHz = 125000;
         txParams.nPreamble = 8;
-        txParams.crcEnabled = 1;
-        txParams.lowDataRateOptimizationEnabled =
-            LoraPhy::GetTSym(txParams) > MilliSeconds(16) ? true : false;
+        txParams.crcEnabled = true;
+        txParams.lowDataRateOptimizationEnabled = LoraPhy::GetTSym(txParams) > MilliSeconds(16);
         Ptr<Packet> pkt = Create<Packet>(packetSize);
 
         LoraFrameHeader frameHdr = LoraFrameHeader();
         frameHdr.SetAsUplink();
         frameHdr.SetFPort(1);
         frameHdr.SetAddress(LoraDeviceAddress());
-        frameHdr.SetAdr(0);
-        frameHdr.SetAdrAckReq(0);
+        frameHdr.SetAdr(false);
+        frameHdr.SetAdrAckReq(false);
         frameHdr.SetFCnt(0);
         pkt->AddHeader(frameHdr);
 
         LorawanMacHeader macHdr = LorawanMacHeader();
-        macHdr.SetMType(ns3::lorawan::LorawanMacHeader::UNCONFIRMED_DATA_UP);
+        macHdr.SetMType(LorawanMacHeader::UNCONFIRMED_DATA_UP);
         macHdr.SetMajor(1);
         pkt->AddHeader(macHdr);
 
@@ -289,7 +288,7 @@ main(int argc, char* argv[])
     forHelper.Install(gateways);
 
     // Install trace sources
-    for (NodeContainer::Iterator node = gateways.Begin(); node != gateways.End(); node++)
+    for (auto node = gateways.Begin(); node != gateways.End(); node++)
     {
         (*node)->GetDevice(0)->GetObject<LoraNetDevice>()->GetPhy()->TraceConnectWithoutContext(
             "ReceivedPacket",
@@ -297,14 +296,14 @@ main(int argc, char* argv[])
     }
 
     // Install trace sources
-    for (NodeContainer::Iterator node = endDevices.Begin(); node != endDevices.End(); node++)
+    for (auto node = endDevices.Begin(); node != endDevices.End(); node++)
     {
         (*node)->GetDevice(0)->GetObject<LoraNetDevice>()->GetPhy()->TraceConnectWithoutContext(
             "StartSending",
             MakeCallback(OnTransmissionCallback));
     }
 
-    macHelper.SetSpreadingFactorsUp(endDevices, gateways, channel);
+    LorawanMacHelper::SetSpreadingFactorsUp(endDevices, gateways, channel);
 
     ////////////////
     // Simulation //

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -167,7 +167,7 @@ main(int argc, char* argv[])
     mobility.Install(endDevices);
 
     // Make it so that nodes are at a certain height > 0
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<MobilityModel> mobility = (*j)->GetObject<MobilityModel>();
         Vector position = mobility->GetPosition();
@@ -190,7 +190,7 @@ main(int argc, char* argv[])
     // Now end devices are connected to the channel
 
     // Connect trace sources
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> node = *j;
         Ptr<LoraNetDevice> loraNetDevice = node->GetDevice(0)->GetObject<LoraNetDevice>();
@@ -226,7 +226,7 @@ main(int argc, char* argv[])
     double deltaY = 17;
     int gridWidth = 2 * radius / (xLength + deltaX);
     int gridHeight = 2 * radius / (yLength + deltaY);
-    if (realisticChannelModel == false)
+    if (!realisticChannelModel)
     {
         gridWidth = 0;
         gridHeight = 0;
@@ -274,7 +274,7 @@ main(int argc, char* argv[])
      *  Set up the end device's spreading factor  *
      **********************************************/
 
-    macHelper.SetSpreadingFactorsUp(endDevices, gateways, channel);
+    LorawanMacHelper::SetSpreadingFactorsUp(endDevices, gateways, channel);
 
     NS_LOG_DEBUG("Completed configuration");
 

--- a/examples/frame-counter-update.cc
+++ b/examples/frame-counter-update.cc
@@ -158,7 +158,7 @@ main(int argc, char* argv[])
     mobility.Install(endDevices);
 
     // Make it so that nodes are at a certain height > 0
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<MobilityModel> mobility = (*j)->GetObject<MobilityModel>();
         Vector position = mobility->GetPosition();
@@ -180,7 +180,7 @@ main(int argc, char* argv[])
     helper.Install(phyHelper, macHelper, endDevices);
 
     // Connect trace sources
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> node = *j;
         Ptr<LoraNetDevice> loraNetDevice = node->GetDevice(0)->GetObject<LoraNetDevice>();

--- a/examples/lorawan-energy-model-example.cc
+++ b/examples/lorawan-energy-model-example.cc
@@ -129,7 +129,7 @@ main(int argc, char* argv[])
     macHelper.SetDeviceType(LorawanMacHelper::GW);
     helper.Install(phyHelper, macHelper, gateways);
 
-    macHelper.SetSpreadingFactorsUp(endDevices, gateways, channel);
+    LorawanMacHelper::SetSpreadingFactorsUp(endDevices, gateways, channel);
 
     /*********************************************
      *  Install applications on the end devices  *

--- a/examples/network-server-example.cc
+++ b/examples/network-server-example.cc
@@ -78,7 +78,8 @@ main(int argc, char* argv[])
     //////////
 
     // End Device mobility
-    MobilityHelper mobilityEd, mobilityGw;
+    MobilityHelper mobilityEd;
+    MobilityHelper mobilityGw;
     Ptr<ListPositionAllocator> positionAllocEd = CreateObject<ListPositionAllocator>();
     positionAllocEd->Add(Vector(6000.0, 0.0, 0.0));
     positionAllocEd->Add(Vector(0.0, 100.0, 0.0));
@@ -153,7 +154,7 @@ main(int argc, char* argv[])
     helper.Install(phyHelper, macHelper, gateways);
 
     // Set spreading factors up
-    macHelper.SetSpreadingFactorsUp(endDevices, gateways, channel);
+    LorawanMacHelper::SetSpreadingFactorsUp(endDevices, gateways, channel);
 
     ////////////
     // Create NS

--- a/examples/simple-network-example.cc
+++ b/examples/simple-network-example.cc
@@ -136,7 +136,7 @@ main(int argc, char* argv[])
      * Set Data Rates *
      ******************/
     std::vector<int> sfQuantity(6);
-    sfQuantity = macHelper.SetSpreadingFactorsUp(endDevices, gateways, channel);
+    sfQuantity = LorawanMacHelper::SetSpreadingFactorsUp(endDevices, gateways, channel);
 
     /****************
      *  Simulation  *

--- a/helper/forwarder-helper.cc
+++ b/helper/forwarder-helper.cc
@@ -59,7 +59,7 @@ ApplicationContainer
 ForwarderHelper::Install(NodeContainer c) const
 {
     ApplicationContainer apps;
-    for (NodeContainer::Iterator i = c.Begin(); i != c.End(); ++i)
+    for (auto i = c.Begin(); i != c.End(); ++i)
     {
         apps.Add(InstallPriv(*i));
     }

--- a/helper/lora-helper.cc
+++ b/helper/lora-helper.cc
@@ -50,7 +50,7 @@ LoraHelper::Install(const LoraPhyHelper& phyHelper,
     NetDeviceContainer devices;
 
     // Go over the various nodes in which to install the NetDevice
-    for (NodeContainer::Iterator i = c.Begin(); i != c.End(); ++i)
+    for (auto i = c.Begin(); i != c.End(); ++i)
     {
         Ptr<Node> node = *i;
 
@@ -151,7 +151,7 @@ LoraHelper::EnablePacketTracking()
 }
 
 LoraPacketTracker&
-LoraHelper::GetPacketTracker(void)
+LoraHelper::GetPacketTracker()
 {
     NS_LOG_FUNCTION(this);
 
@@ -161,7 +161,7 @@ LoraHelper::GetPacketTracker(void)
 void
 LoraHelper::EnableSimulationTimePrinting(Time interval)
 {
-    m_oldtime = std::time(0);
+    m_oldtime = std::time(nullptr);
     Simulator::Schedule(Seconds(0), &LoraHelper::DoPrintSimulationTime, this, interval);
 }
 
@@ -204,7 +204,7 @@ LoraHelper::DoPrintDeviceStatus(NodeContainer endDevices,
     }
 
     Time currentTime = Simulator::Now();
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> object = *j;
         Ptr<MobilityModel> position = object->GetObject<MobilityModel>();
@@ -329,9 +329,9 @@ LoraHelper::DoPrintSimulationTime(Time interval)
 {
     // NS_LOG_INFO ("Time: " << Simulator::Now().GetHours());
     std::cout << "Simulated time: " << Simulator::Now().GetHours() << " hours" << std::endl;
-    std::cout << "Real time from last call: " << std::time(0) - m_oldtime << " seconds"
+    std::cout << "Real time from last call: " << std::time(nullptr) - m_oldtime << " seconds"
               << std::endl;
-    m_oldtime = std::time(0);
+    m_oldtime = std::time(nullptr);
     Simulator::Schedule(interval, &LoraHelper::DoPrintSimulationTime, this, interval);
 }
 

--- a/helper/lora-helper.h
+++ b/helper/lora-helper.h
@@ -81,7 +81,7 @@ class LoraHelper
      * This method automatically connects to trace sources to computes relevant
      * metrics.
      */
-    void EnablePacketTracking(void);
+    void EnablePacketTracking();
 
     /**
      * Periodically prints the simulation time to the standard output.
@@ -112,9 +112,9 @@ class LoraHelper
 
     void DoPrintGlobalPerformance(std::string filename);
 
-    LoraPacketTracker& GetPacketTracker(void);
+    LoraPacketTracker& GetPacketTracker();
 
-    LoraPacketTracker* m_packetTracker = 0;
+    LoraPacketTracker* m_packetTracker = nullptr;
 
     time_t m_oldtime;
 

--- a/helper/lora-packet-tracker.cc
+++ b/helper/lora-packet-tracker.cc
@@ -132,7 +132,7 @@ LoraPacketTracker::PacketReceptionCallback(Ptr<const Packet> packet, uint32_t gw
         // Remove the successfully received packet from the list of sent ones
         NS_LOG_INFO("PHY packet " << packet << " was successfully received at gateway " << gwId);
 
-        std::map<Ptr<const Packet>, PacketStatus>::iterator it = m_packetTracker.find(packet);
+        auto it = m_packetTracker.find(packet);
         (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome>(gwId, RECEIVED));
     }
 }
@@ -144,7 +144,7 @@ LoraPacketTracker::InterferenceCallback(Ptr<const Packet> packet, uint32_t gwId)
     {
         NS_LOG_INFO("PHY packet " << packet << " was interfered at gateway " << gwId);
 
-        std::map<Ptr<const Packet>, PacketStatus>::iterator it = m_packetTracker.find(packet);
+        auto it = m_packetTracker.find(packet);
         (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome>(gwId, INTERFERED));
     }
 }
@@ -156,7 +156,7 @@ LoraPacketTracker::NoMoreReceiversCallback(Ptr<const Packet> packet, uint32_t gw
     {
         NS_LOG_INFO("PHY packet " << packet << " was lost because no more receivers at gateway "
                                   << gwId);
-        std::map<Ptr<const Packet>, PacketStatus>::iterator it = m_packetTracker.find(packet);
+        auto it = m_packetTracker.find(packet);
         (*it).second.outcomes.insert(
             std::pair<int, enum PhyPacketOutcome>(gwId, NO_MORE_RECEIVERS));
     }
@@ -170,7 +170,7 @@ LoraPacketTracker::UnderSensitivityCallback(Ptr<const Packet> packet, uint32_t g
         NS_LOG_INFO("PHY packet " << packet << " was lost because under sensitivity at gateway "
                                   << gwId);
 
-        std::map<Ptr<const Packet>, PacketStatus>::iterator it = m_packetTracker.find(packet);
+        auto it = m_packetTracker.find(packet);
         (*it).second.outcomes.insert(
             std::pair<int, enum PhyPacketOutcome>(gwId, UNDER_SENSITIVITY));
     }
@@ -184,7 +184,7 @@ LoraPacketTracker::LostBecauseTxCallback(Ptr<const Packet> packet, uint32_t gwId
         NS_LOG_INFO("PHY packet " << packet << " was lost because of GW transmission at gateway "
                                   << gwId);
 
-        std::map<Ptr<const Packet>, PacketStatus>::iterator it = m_packetTracker.find(packet);
+        auto it = m_packetTracker.find(packet);
         (*it).second.outcomes.insert(std::pair<int, enum PhyPacketOutcome>(gwId, LOST_BECAUSE_TX));
     }
 }
@@ -330,7 +330,7 @@ LoraPacketTracker::CountMacPacketsGlobally(Time startTime, Time stopTime)
         if ((*it).second.sendTime >= startTime && (*it).second.sendTime <= stopTime)
         {
             sent++;
-            if ((*it).second.receptionTimes.size())
+            if (!(*it).second.receptionTimes.empty())
             {
                 received++;
             }

--- a/helper/lora-phy-helper.cc
+++ b/helper/lora-phy-helper.cc
@@ -58,7 +58,7 @@ LoraPhyHelper::SetDeviceType(enum DeviceType dt)
 }
 
 TypeId
-LoraPhyHelper::GetDeviceType(void) const
+LoraPhyHelper::GetDeviceType() const
 {
     NS_LOG_FUNCTION(this);
     return m_phy.GetTypeId();

--- a/helper/lora-phy-helper.h
+++ b/helper/lora-phy-helper.h
@@ -70,7 +70,7 @@ class LoraPhyHelper
      */
     void SetDeviceType(enum DeviceType dt);
 
-    TypeId GetDeviceType(void) const;
+    TypeId GetDeviceType() const;
 
     /**
      * Set an attribute of the underlying PHY object.

--- a/helper/lora-radio-energy-model-helper.cc
+++ b/helper/lora-radio-energy-model-helper.cc
@@ -81,17 +81,17 @@ LoraRadioEnergyModelHelper::SetTxCurrentModel(std::string name,
 Ptr<DeviceEnergyModel>
 LoraRadioEnergyModelHelper::DoInstall(Ptr<NetDevice> device, Ptr<EnergySource> source) const
 {
-    NS_ASSERT(device != NULL);
-    NS_ASSERT(source != NULL);
+    NS_ASSERT(device);
+    NS_ASSERT(source);
     // check if device is LoraNetDevice
     std::string deviceName = device->GetInstanceTypeId().GetName();
-    if (deviceName.compare("ns3::LoraNetDevice") != 0)
+    if (deviceName != "ns3::LoraNetDevice")
     {
         NS_FATAL_ERROR("NetDevice type is not LoraNetDevice!");
     }
     Ptr<Node> node = device->GetNode();
     Ptr<LoraRadioEnergyModel> model = m_radioEnergy.Create()->GetObject<LoraRadioEnergyModel>();
-    NS_ASSERT(model != NULL);
+    NS_ASSERT(model);
     // set energy source pointer
     model->SetEnergySource(source);
 

--- a/helper/lora-radio-energy-model-helper.h
+++ b/helper/lora-radio-energy-model-helper.h
@@ -45,7 +45,7 @@ class LoraRadioEnergyModelHelper : public DeviceEnergyModelHelper
     /**
      * Destroy a RadioEnergy Helper
      */
-    ~LoraRadioEnergyModelHelper();
+    ~LoraRadioEnergyModelHelper() override;
 
     /**
      * \param name the name of the attribute to set
@@ -53,7 +53,7 @@ class LoraRadioEnergyModelHelper : public DeviceEnergyModelHelper
      *
      * Sets an attribute of the underlying PHY object.
      */
-    void Set(std::string name, const AttributeValue& v);
+    void Set(std::string name, const AttributeValue& v) override;
 
     /**
      * \param name the name of the model to set
@@ -102,7 +102,8 @@ class LoraRadioEnergyModelHelper : public DeviceEnergyModelHelper
      *
      * Implements DeviceEnergyModel::Install.
      */
-    virtual Ptr<DeviceEnergyModel> DoInstall(Ptr<NetDevice> device, Ptr<EnergySource> source) const;
+    Ptr<DeviceEnergyModel> DoInstall(Ptr<NetDevice> device,
+                                     Ptr<EnergySource> source) const override;
 
   private:
     ObjectFactory m_radioEnergy;    ///< radio energy

--- a/helper/lorawan-mac-helper.cc
+++ b/helper/lorawan-mac-helper.cc
@@ -461,7 +461,7 @@ LorawanMacHelper::SetSpreadingFactorsUp(NodeContainer endDevices,
     NS_LOG_FUNCTION_NOARGS();
 
     std::vector<int> sfQuantity(7, 0);
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> object = *j;
         Ptr<MobilityModel> position = object->GetObject<MobilityModel>();
@@ -480,8 +480,7 @@ LorawanMacHelper::SetSpreadingFactorsUp(NodeContainer endDevices,
         // Assume devices transmit at 14 dBm
         double highestRxPower = channel->GetRxPower(14, position, bestGatewayPosition);
 
-        for (NodeContainer::Iterator currentGw = gateways.Begin() + 1; currentGw != gateways.End();
-             ++currentGw)
+        for (auto currentGw = gateways.Begin() + 1; currentGw != gateways.End(); ++currentGw)
         {
             // Compute the power received from the current gateway
             Ptr<Node> curr = *currentGw;
@@ -620,7 +619,7 @@ LorawanMacHelper::SetSpreadingFactorsGivenDistribution(NodeContainer endDevices,
                                              << cumdistr[2] << " " << cumdistr[3] << " "
                                              << cumdistr[4] << " " << cumdistr[5]);
 
-    for (NodeContainer::Iterator j = endDevices.Begin(); j != endDevices.End(); ++j)
+    for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> object = *j;
         Ptr<MobilityModel> position = object->GetObject<MobilityModel>();

--- a/helper/network-server-helper.cc
+++ b/helper/network-server-helper.cc
@@ -74,7 +74,7 @@ ApplicationContainer
 NetworkServerHelper::Install(NodeContainer c)
 {
     ApplicationContainer apps;
-    for (NodeContainer::Iterator i = c.Begin(); i != c.End(); ++i)
+    for (auto i = c.Begin(); i != c.End(); ++i)
     {
         apps.Add(InstallPriv(*i));
     }
@@ -93,7 +93,7 @@ NetworkServerHelper::InstallPriv(Ptr<Node> node)
     node->AddApplication(app);
 
     // Cycle on each gateway
-    for (NodeContainer::Iterator i = m_gateways.Begin(); i != m_gateways.End(); i++)
+    for (auto i = m_gateways.Begin(); i != m_gateways.End(); i++)
     {
         // Add the connections with the gateway
         // Create a PointToPoint link between gateway and NS

--- a/helper/one-shot-sender-helper.cc
+++ b/helper/one-shot-sender-helper.cc
@@ -64,7 +64,7 @@ ApplicationContainer
 OneShotSenderHelper::Install(NodeContainer c) const
 {
     ApplicationContainer apps;
-    for (NodeContainer::Iterator i = c.Begin(); i != c.End(); ++i)
+    for (auto i = c.Begin(); i != c.End(); ++i)
     {
         apps.Add(InstallPriv(*i));
     }

--- a/helper/periodic-sender-helper.cc
+++ b/helper/periodic-sender-helper.cc
@@ -49,7 +49,7 @@ PeriodicSenderHelper::PeriodicSenderHelper()
     m_intervalProb->SetAttribute("Max", DoubleValue(1));
 
     m_pktSize = 10;
-    m_pktSizeRV = 0;
+    m_pktSizeRV = nullptr;
 }
 
 PeriodicSenderHelper::~PeriodicSenderHelper()
@@ -72,7 +72,7 @@ ApplicationContainer
 PeriodicSenderHelper::Install(NodeContainer c) const
 {
     ApplicationContainer apps;
-    for (NodeContainer::Iterator i = c.Begin(); i != c.End(); ++i)
+    for (auto i = c.Begin(); i != c.End(); ++i)
     {
         apps.Add(InstallPriv(*i));
     }

--- a/model/adr-component.cc
+++ b/model/adr-component.cc
@@ -33,7 +33,7 @@ NS_LOG_COMPONENT_DEFINE("AdrComponent");
 NS_OBJECT_ENSURE_REGISTERED(AdrComponent);
 
 TypeId
-AdrComponent::GetTypeId(void)
+AdrComponent::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::AdrComponent")
@@ -283,7 +283,7 @@ AdrComponent::SfToDr(uint8_t sf)
 }
 
 double
-AdrComponent::RxPowerToSNR(double transmissionPower)
+AdrComponent::RxPowerToSNR(double transmissionPower) const
 {
     // The following conversion ignores interfering packets
     return transmissionPower + 174 - 10 * log10(B) - NF;
@@ -293,7 +293,7 @@ AdrComponent::RxPowerToSNR(double transmissionPower)
 double
 AdrComponent::GetMinTxFromGateways(EndDeviceStatus::GatewayList gwList)
 {
-    EndDeviceStatus::GatewayList::iterator it = gwList.begin();
+    auto it = gwList.begin();
     double min = it->second.rxPower;
 
     for (; it != gwList.end(); it++)
@@ -311,7 +311,7 @@ AdrComponent::GetMinTxFromGateways(EndDeviceStatus::GatewayList gwList)
 double
 AdrComponent::GetMaxTxFromGateways(EndDeviceStatus::GatewayList gwList)
 {
-    EndDeviceStatus::GatewayList::iterator it = gwList.begin();
+    auto it = gwList.begin();
     double max = it->second.rxPower;
 
     for (; it != gwList.end(); it++)
@@ -331,7 +331,7 @@ AdrComponent::GetAverageTxFromGateways(EndDeviceStatus::GatewayList gwList)
 {
     double sum = 0;
 
-    for (EndDeviceStatus::GatewayList::iterator it = gwList.begin(); it != gwList.end(); it++)
+    for (auto it = gwList.begin(); it != gwList.end(); it++)
     {
         NS_LOG_DEBUG("Gateway at " << it->first << " has TP " << it->second.rxPower);
         sum += it->second.rxPower;

--- a/model/adr-component.h
+++ b/model/adr-component.h
@@ -46,27 +46,27 @@ class AdrComponent : public NetworkControllerComponent
     };
 
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     // Constructor
     AdrComponent();
     // Destructor
-    virtual ~AdrComponent();
+    ~AdrComponent() override;
 
     void OnReceivedPacket(Ptr<const Packet> packet,
                           Ptr<EndDeviceStatus> status,
-                          Ptr<NetworkStatus> networkStatus);
+                          Ptr<NetworkStatus> networkStatus) override;
 
-    void BeforeSendingReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus);
+    void BeforeSendingReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus) override;
 
-    void OnFailedReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus);
+    void OnFailedReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus) override;
 
   private:
     void AdrImplementation(uint8_t* newDataRate, uint8_t* newTxPower, Ptr<EndDeviceStatus> status);
 
     uint8_t SfToDr(uint8_t sf);
 
-    double RxPowerToSNR(double transmissionPower);
+    double RxPowerToSNR(double transmissionPower) const;
 
     double GetMinTxFromGateways(EndDeviceStatus::GatewayList gwList);
 

--- a/model/building-penetration-loss.cc
+++ b/model/building-penetration-loss.cc
@@ -33,7 +33,7 @@ NS_LOG_COMPONENT_DEFINE("BuildingPenetrationLoss");
 NS_OBJECT_ENSURE_REGISTERED(BuildingPenetrationLoss);
 
 TypeId
-BuildingPenetrationLoss::GetTypeId(void)
+BuildingPenetrationLoss::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::BuildingPenetrationLoss")
                             .SetParent<PropagationLossModel>()
@@ -136,7 +136,7 @@ BuildingPenetrationLoss::DoAssignStreams(int64_t stream)
 }
 
 int
-BuildingPenetrationLoss::GetPValue(void) const
+BuildingPenetrationLoss::GetPValue() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -163,7 +163,7 @@ BuildingPenetrationLoss::GetPValue(void) const
 }
 
 int
-BuildingPenetrationLoss::GetWallLossValue(void) const
+BuildingPenetrationLoss::GetWallLossValue() const
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/building-penetration-loss.h
+++ b/model/building-penetration-loss.h
@@ -36,36 +36,36 @@ namespace lorawan
 class BuildingPenetrationLoss : public PropagationLossModel
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     BuildingPenetrationLoss();
 
-    ~BuildingPenetrationLoss();
+    ~BuildingPenetrationLoss() override;
 
   private:
     /**
      * Perform the computation of the received power according to the current
      * model.
      */
-    virtual double DoCalcRxPower(double txPowerDbm,
-                                 Ptr<MobilityModel> a,
-                                 Ptr<MobilityModel> b) const;
+    double DoCalcRxPower(double txPowerDbm,
+                         Ptr<MobilityModel> a,
+                         Ptr<MobilityModel> b) const override;
 
-    virtual int64_t DoAssignStreams(int64_t stream);
+    int64_t DoAssignStreams(int64_t stream) override;
 
     /**
      * Generate a random p value.
      * The distribution of the returned value is as specified in TR 45.820.
      * \returns A value in the 0-3 range.
      */
-    int GetPValue(void) const;
+    int GetPValue() const;
 
     /**
      * Get a value to compute the wall loss.
      * The distribution of the returned value is as specified in TR 45.820.
      * \returns A value in the 0-2 range.
      */
-    int GetWallLossValue(void) const;
+    int GetWallLossValue() const;
 
     /**
      * Compute the wall loss associated to this mobility model

--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -40,7 +40,7 @@ NS_LOG_COMPONENT_DEFINE("ClassAEndDeviceLorawanMac");
 NS_OBJECT_ENSURE_REGISTERED(ClassAEndDeviceLorawanMac);
 
 TypeId
-ClassAEndDeviceLorawanMac::GetTypeId(void)
+ClassAEndDeviceLorawanMac::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::ClassAEndDeviceLorawanMac")
                             .SetParent<EndDeviceLorawanMac>()
@@ -100,9 +100,8 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packetToSend)
     params.codingRate = m_codingRate;
     params.bandwidthHz = GetBandwidthFromDataRate(m_dataRate);
     params.nPreamble = m_nPreambleSymbols;
-    params.crcEnabled = 1;
-    params.lowDataRateOptimizationEnabled =
-        LoraPhy::GetTSym(params) > MilliSeconds(16) ? true : false;
+    params.crcEnabled = true;
+    params.lowDataRateOptimizationEnabled = LoraPhy::GetTSym(params) > MilliSeconds(16);
 
     // Wake up PHY layer and directly send the packet
 
@@ -298,7 +297,7 @@ ClassAEndDeviceLorawanMac::TxFinished(Ptr<const Packet> packet)
 }
 
 void
-ClassAEndDeviceLorawanMac::OpenFirstReceiveWindow(void)
+ClassAEndDeviceLorawanMac::OpenFirstReceiveWindow()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -318,7 +317,7 @@ ClassAEndDeviceLorawanMac::OpenFirstReceiveWindow(void)
 }
 
 void
-ClassAEndDeviceLorawanMac::CloseFirstReceiveWindow(void)
+ClassAEndDeviceLorawanMac::CloseFirstReceiveWindow()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -349,7 +348,7 @@ ClassAEndDeviceLorawanMac::CloseFirstReceiveWindow(void)
 }
 
 void
-ClassAEndDeviceLorawanMac::OpenSecondReceiveWindow(void)
+ClassAEndDeviceLorawanMac::OpenSecondReceiveWindow()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -386,7 +385,7 @@ ClassAEndDeviceLorawanMac::OpenSecondReceiveWindow(void)
 }
 
 void
-ClassAEndDeviceLorawanMac::CloseSecondReceiveWindow(void)
+ClassAEndDeviceLorawanMac::CloseSecondReceiveWindow()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -503,7 +502,7 @@ ClassAEndDeviceLorawanMac::GetNextClassTransmissionDelay(Time waitingTime)
 }
 
 uint8_t
-ClassAEndDeviceLorawanMac::GetFirstReceiveWindowDataRate(void)
+ClassAEndDeviceLorawanMac::GetFirstReceiveWindowDataRate()
 {
     return m_replyDataRateMatrix.at(m_dataRate).at(m_rx1DrOffset);
 }
@@ -515,7 +514,7 @@ ClassAEndDeviceLorawanMac::SetSecondReceiveWindowDataRate(uint8_t dataRate)
 }
 
 uint8_t
-ClassAEndDeviceLorawanMac::GetSecondReceiveWindowDataRate(void)
+ClassAEndDeviceLorawanMac::GetSecondReceiveWindowDataRate() const
 {
     return m_secondReceiveWindowDataRate;
 }
@@ -527,7 +526,7 @@ ClassAEndDeviceLorawanMac::SetSecondReceiveWindowFrequency(double frequencyMHz)
 }
 
 double
-ClassAEndDeviceLorawanMac::GetSecondReceiveWindowFrequency(void)
+ClassAEndDeviceLorawanMac::GetSecondReceiveWindowFrequency() const
 {
     return m_secondReceiveWindowFrequency;
 }
@@ -569,7 +568,7 @@ ClassAEndDeviceLorawanMac::OnRxClassParamSetupReq(Ptr<RxParamSetupReq> rxParamSe
 
     // Craft a RxParamSetupAns as response
     NS_LOG_INFO("Adding RxParamSetupAns reply");
-    m_macCommandList.push_back(CreateObject<RxParamSetupAns>(offsetOk, dataRateOk, true));
+    m_macCommandList.emplace_back(CreateObject<RxParamSetupAns>(offsetOk, dataRateOk, true));
 }
 
 } /* namespace lorawan */

--- a/model/class-a-end-device-lorawan-mac.h
+++ b/model/class-a-end-device-lorawan-mac.h
@@ -42,10 +42,10 @@ namespace lorawan
 class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     ClassAEndDeviceLorawanMac();
-    virtual ~ClassAEndDeviceLorawanMac();
+    ~ClassAEndDeviceLorawanMac() override;
 
     /////////////////////
     // Sending methods //
@@ -56,7 +56,7 @@ class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
      *
      * \param packet the packet to send
      */
-    virtual void SendToPhy(Ptr<Packet> packet);
+    void SendToPhy(Ptr<Packet> packet) override;
 
     //////////////////////////
     //  Receiving methods   //
@@ -70,36 +70,36 @@ class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
      *
      * \param packet the received packet.
      */
-    virtual void Receive(Ptr<const Packet> packet);
+    void Receive(Ptr<const Packet> packet) override;
 
-    virtual void FailedReception(Ptr<const Packet> packet);
+    void FailedReception(Ptr<const Packet> packet) override;
 
     /**
      * Perform the actions that are required after a packet send.
      *
      * This function handles opening of the first receive window.
      */
-    virtual void TxFinished(Ptr<const Packet> packet);
+    void TxFinished(Ptr<const Packet> packet) override;
 
     /**
      * Perform operations needed to open the first receive window.
      */
-    void OpenFirstReceiveWindow(void);
+    void OpenFirstReceiveWindow();
 
     /**
      * Perform operations needed to open the second receive window.
      */
-    void OpenSecondReceiveWindow(void);
+    void OpenSecondReceiveWindow();
 
     /**
      * Perform operations needed to close the first receive window.
      */
-    void CloseFirstReceiveWindow(void);
+    void CloseFirstReceiveWindow();
 
     /**
      * Perform operations needed to close the second receive window.
      */
-    void CloseSecondReceiveWindow(void);
+    void CloseSecondReceiveWindow();
 
     /////////////////////////
     // Getters and Setters //
@@ -112,14 +112,14 @@ class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
      * \param waitingTime The minimum waiting time that has to be respected,
      * irrespective of the class (e.g., because of duty cycle limitations).
      */
-    virtual Time GetNextClassTransmissionDelay(Time waitingTime);
+    Time GetNextClassTransmissionDelay(Time waitingTime) override;
 
     /**
      * Get the Data Rate that will be used in the first receive window.
      *
      * \return The Data Rate
      */
-    uint8_t GetFirstReceiveWindowDataRate(void);
+    uint8_t GetFirstReceiveWindowDataRate();
 
     /**
      * Set the Data Rate to be used in the second receive window.
@@ -133,7 +133,7 @@ class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
      *
      * \return The Data Rate
      */
-    uint8_t GetSecondReceiveWindowDataRate(void);
+    uint8_t GetSecondReceiveWindowDataRate() const;
 
     /**
      * Set the frequency that will be used for the second receive window.
@@ -147,7 +147,7 @@ class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
      *
      * @return The frequency, in MHz
      */
-    double GetSecondReceiveWindowFrequency(void);
+    double GetSecondReceiveWindowFrequency() const;
 
     /////////////////////////
     // MAC command methods //
@@ -162,7 +162,7 @@ class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
      *                            - The data rate to use for the second receive window.
      *                            - The frequency to use for the second receive window.
      */
-    virtual void OnRxClassParamSetupReq(Ptr<RxParamSetupReq> rxParamSetupReq);
+    void OnRxClassParamSetupReq(Ptr<RxParamSetupReq> rxParamSetupReq) override;
 
   private:
     /**

--- a/model/correlated-shadowing-propagation-loss-model.cc
+++ b/model/correlated-shadowing-propagation-loss-model.cc
@@ -32,7 +32,7 @@ NS_LOG_COMPONENT_DEFINE("CorrelatedShadowingPropagationLossModel");
 NS_OBJECT_ENSURE_REGISTERED(CorrelatedShadowingPropagationLossModel);
 
 TypeId
-CorrelatedShadowingPropagationLossModel::GetTypeId(void)
+CorrelatedShadowingPropagationLossModel::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::CorrelatedShwodingPropagationLossModel")

--- a/model/correlated-shadowing-propagation-loss-model.h
+++ b/model/correlated-shadowing-propagation-loss-model.h
@@ -107,7 +107,7 @@ class CorrelatedShadowingPropagationLossModel : public PropagationLossModel
         static const double m_kInv[4][4];
     };
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     /**
      * Constructor.
@@ -122,14 +122,14 @@ class CorrelatedShadowingPropagationLossModel : public PropagationLossModel
     /**
      * Get the correlation distance that is currently being used.
      */
-    double GetCorrelationDistance(void);
+    double GetCorrelationDistance();
 
   private:
-    virtual double DoCalcRxPower(double txPowerDbm,
-                                 Ptr<MobilityModel> a,
-                                 Ptr<MobilityModel> b) const;
+    double DoCalcRxPower(double txPowerDbm,
+                         Ptr<MobilityModel> a,
+                         Ptr<MobilityModel> b) const override;
 
-    virtual int64_t DoAssignStreams(int64_t stream);
+    int64_t DoAssignStreams(int64_t stream) override;
 
     double m_correlationDistance; //!< The correlation distance for the ShadowingMap
 

--- a/model/end-device-lora-phy.cc
+++ b/model/end-device-lora-phy.cc
@@ -44,7 +44,7 @@ EndDeviceLoraPhyListener::~EndDeviceLoraPhyListener()
 }
 
 TypeId
-EndDeviceLoraPhy::GetTypeId(void)
+EndDeviceLoraPhy::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::EndDeviceLoraPhy")
@@ -94,13 +94,13 @@ EndDeviceLoraPhy::SetSpreadingFactor(uint8_t sf)
 }
 
 uint8_t
-EndDeviceLoraPhy::GetSpreadingFactor(void)
+EndDeviceLoraPhy::GetSpreadingFactor() const
 {
     return m_sf;
 }
 
 bool
-EndDeviceLoraPhy::IsTransmitting(void)
+EndDeviceLoraPhy::IsTransmitting()
 {
     return m_state == TX;
 }
@@ -118,21 +118,21 @@ EndDeviceLoraPhy::SetFrequency(double frequencyMHz)
 }
 
 void
-EndDeviceLoraPhy::SwitchToStandby(void)
+EndDeviceLoraPhy::SwitchToStandby()
 {
     NS_LOG_FUNCTION_NOARGS();
 
     m_state = STANDBY;
 
     // Notify listeners of the state change
-    for (Listeners::const_iterator i = m_listeners.begin(); i != m_listeners.end(); i++)
+    for (auto i = m_listeners.begin(); i != m_listeners.end(); i++)
     {
         (*i)->NotifyStandby();
     }
 }
 
 void
-EndDeviceLoraPhy::SwitchToRx(void)
+EndDeviceLoraPhy::SwitchToRx()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -141,7 +141,7 @@ EndDeviceLoraPhy::SwitchToRx(void)
     m_state = RX;
 
     // Notify listeners of the state change
-    for (Listeners::const_iterator i = m_listeners.begin(); i != m_listeners.end(); i++)
+    for (auto i = m_listeners.begin(); i != m_listeners.end(); i++)
     {
         (*i)->NotifyRxStart();
     }
@@ -157,14 +157,14 @@ EndDeviceLoraPhy::SwitchToTx(double txPowerDbm)
     m_state = TX;
 
     // Notify listeners of the state change
-    for (Listeners::const_iterator i = m_listeners.begin(); i != m_listeners.end(); i++)
+    for (auto i = m_listeners.begin(); i != m_listeners.end(); i++)
     {
         (*i)->NotifyTxStart(txPowerDbm);
     }
 }
 
 void
-EndDeviceLoraPhy::SwitchToSleep(void)
+EndDeviceLoraPhy::SwitchToSleep()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -173,14 +173,14 @@ EndDeviceLoraPhy::SwitchToSleep(void)
     m_state = SLEEP;
 
     // Notify listeners of the state change
-    for (Listeners::const_iterator i = m_listeners.begin(); i != m_listeners.end(); i++)
+    for (auto i = m_listeners.begin(); i != m_listeners.end(); i++)
     {
         (*i)->NotifySleep();
     }
 }
 
 EndDeviceLoraPhy::State
-EndDeviceLoraPhy::GetState(void)
+EndDeviceLoraPhy::GetState()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -196,7 +196,7 @@ EndDeviceLoraPhy::RegisterListener(EndDeviceLoraPhyListener* listener)
 void
 EndDeviceLoraPhy::UnregisterListener(EndDeviceLoraPhyListener* listener)
 {
-    ListenersI i = find(m_listeners.begin(), m_listeners.end(), listener);
+    auto i = find(m_listeners.begin(), m_listeners.end(), listener);
     if (i != m_listeners.end())
     {
         m_listeners.erase(i);

--- a/model/end-device-lora-phy.h
+++ b/model/end-device-lora-phy.h
@@ -75,12 +75,12 @@ class EndDeviceLoraPhyListener
     /**
      * Notify listeners that we went to sleep
      */
-    virtual void NotifySleep(void) = 0;
+    virtual void NotifySleep() = 0;
 
     /**
      * Notify listeners that we woke up
      */
-    virtual void NotifyStandby(void) = 0;
+    virtual void NotifyStandby() = 0;
 };
 
 /**
@@ -142,33 +142,33 @@ class EndDeviceLoraPhy : public LoraPhy
         RX
     };
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     // Constructor and destructor
     EndDeviceLoraPhy();
-    virtual ~EndDeviceLoraPhy();
+    ~EndDeviceLoraPhy() override;
 
     // Implementation of LoraPhy's pure virtual functions
-    virtual void StartReceive(Ptr<Packet> packet,
-                              double rxPowerDbm,
-                              uint8_t sf,
-                              Time duration,
-                              double frequencyMHz) = 0;
+    void StartReceive(Ptr<Packet> packet,
+                      double rxPowerDbm,
+                      uint8_t sf,
+                      Time duration,
+                      double frequencyMHz) override = 0;
 
     // Implementation of LoraPhy's pure virtual functions
-    virtual void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) = 0;
+    void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) override = 0;
 
     // Implementation of LoraPhy's pure virtual functions
-    virtual void Send(Ptr<Packet> packet,
-                      LoraTxParameters txParams,
-                      double frequencyMHz,
-                      double txPowerDbm) = 0;
+    void Send(Ptr<Packet> packet,
+              LoraTxParameters txParams,
+              double frequencyMHz,
+              double txPowerDbm) override = 0;
 
     // Implementation of LoraPhy's pure virtual functions
-    virtual bool IsOnFrequency(double frequencyMHz);
+    bool IsOnFrequency(double frequencyMHz) override;
 
     // Implementation of LoraPhy's pure virtual functions
-    virtual bool IsTransmitting(void);
+    bool IsTransmitting() override;
 
     /**
      * Set the frequency this EndDevice will listen on.
@@ -195,24 +195,24 @@ class EndDeviceLoraPhy : public LoraPhy
      *
      * \return The Spreading Factor we are listening for.
      */
-    uint8_t GetSpreadingFactor(void);
+    uint8_t GetSpreadingFactor() const;
 
     /**
      * Return the state this End Device is currently in.
      *
      * \return The state this EndDeviceLoraPhy is currently in.
      */
-    EndDeviceLoraPhy::State GetState(void);
+    EndDeviceLoraPhy::State GetState();
 
     /**
      * Switch to the STANDBY state.
      */
-    void SwitchToStandby(void);
+    void SwitchToStandby();
 
     /**
      * Switch to the SLEEP state.
      */
-    void SwitchToSleep(void);
+    void SwitchToSleep();
 
     /**
      * Add the input listener to the list of objects to be notified of PHY-level

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -40,7 +40,7 @@ NS_LOG_COMPONENT_DEFINE("EndDeviceLorawanMac");
 NS_OBJECT_ENSURE_REGISTERED(EndDeviceLorawanMac);
 
 TypeId
-EndDeviceLorawanMac::GetTypeId(void)
+EndDeviceLorawanMac::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::EndDeviceLorawanMac")
@@ -114,7 +114,7 @@ EndDeviceLorawanMac::EndDeviceLorawanMac()
       m_txPower(14),
       m_codingRate(1),
       // LoraWAN default
-      m_headerDisabled(0),
+      m_headerDisabled(false),
       // LoraWAN default
       m_address(LoraDeviceAddress(0)),
       // LoraWAN default
@@ -470,7 +470,7 @@ EndDeviceLorawanMac::ApplyNecessaryOptions(LoraFrameHeader& frameHeader)
     frameHeader.SetFPort(1); // TODO Use an appropriate frame port based on the application
     frameHeader.SetAddress(m_address);
     frameHeader.SetAdr(m_controlDataRate);
-    frameHeader.SetAdrAckReq(0); // TODO Set ADRACKREQ if a member variable is true
+    frameHeader.SetAdrAckReq(false); // TODO Set ADRACKREQ if a member variable is true
 
     // FPending does not exist in uplink messages
     frameHeader.SetFCnt(m_currentFCnt);
@@ -502,7 +502,7 @@ EndDeviceLorawanMac::SetMType(LorawanMacHeader::MType mType)
 }
 
 LorawanMacHeader::MType
-EndDeviceLorawanMac::GetMType(void)
+EndDeviceLorawanMac::GetMType()
 {
     return m_mType;
 }
@@ -520,7 +520,7 @@ EndDeviceLorawanMac::GetNextClassTransmissionDelay(Time waitingTime)
 }
 
 Time
-EndDeviceLorawanMac::GetNextTransmissionDelay(void)
+EndDeviceLorawanMac::GetNextTransmissionDelay()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -554,7 +554,7 @@ EndDeviceLorawanMac::GetNextTransmissionDelay(void)
 }
 
 Ptr<LogicalLoraChannel>
-EndDeviceLorawanMac::GetChannelForTx(void)
+EndDeviceLorawanMac::GetChannelForTx()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -590,7 +590,7 @@ EndDeviceLorawanMac::GetChannelForTx(void)
                          << "the current channel because of duty cycle limitations.");
         }
     }
-    return 0; // In this case, no suitable channel was found
+    return nullptr; // In this case, no suitable channel was found
 }
 
 std::vector<Ptr<LogicalLoraChannel>>
@@ -620,7 +620,7 @@ EndDeviceLorawanMac::resetRetransmissionParameters()
 {
     m_retxParams.waitingAck = false;
     m_retxParams.retxLeft = m_maxNumbTx;
-    m_retxParams.packet = 0;
+    m_retxParams.packet = nullptr;
     m_retxParams.firstAttempt = Seconds(0);
 
     // Cancel next retransmissions, if any
@@ -635,7 +635,7 @@ EndDeviceLorawanMac::SetDataRateAdaptation(bool adapt)
 }
 
 bool
-EndDeviceLorawanMac::GetDataRateAdaptation(void)
+EndDeviceLorawanMac::GetDataRateAdaptation() const
 {
     return m_enableDRAdapt;
 }
@@ -649,7 +649,7 @@ EndDeviceLorawanMac::SetMaxNumberOfTransmissions(uint8_t maxNumbTx)
 }
 
 uint8_t
-EndDeviceLorawanMac::GetMaxNumberOfTransmissions(void)
+EndDeviceLorawanMac::GetMaxNumberOfTransmissions()
 {
     NS_LOG_FUNCTION(this);
     return m_maxNumbTx;
@@ -664,7 +664,7 @@ EndDeviceLorawanMac::SetDataRate(uint8_t dataRate)
 }
 
 uint8_t
-EndDeviceLorawanMac::GetDataRate(void)
+EndDeviceLorawanMac::GetDataRate()
 {
     NS_LOG_FUNCTION(this);
 
@@ -680,7 +680,7 @@ EndDeviceLorawanMac::SetDeviceAddress(LoraDeviceAddress address)
 }
 
 LoraDeviceAddress
-EndDeviceLorawanMac::GetDeviceAddress(void)
+EndDeviceLorawanMac::GetDeviceAddress()
 {
     NS_LOG_FUNCTION(this);
 
@@ -807,7 +807,7 @@ EndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
 
     // Craft a LinkAdrAns MAC command as a response
     ///////////////////////////////////////////////
-    m_macCommandList.push_back(CreateObject<LinkAdrAns>(txPowerOk, dataRateOk, channelMaskOk));
+    m_macCommandList.emplace_back(CreateObject<LinkAdrAns>(txPowerOk, dataRateOk, channelMaskOk));
 }
 
 void
@@ -823,7 +823,7 @@ EndDeviceLorawanMac::OnDutyCycleReq(double dutyCycle)
 
     // Craft a DutyCycleAns as response
     NS_LOG_INFO("Adding DutyCycleAns reply");
-    m_macCommandList.push_back(CreateObject<DutyCycleAns>());
+    m_macCommandList.emplace_back(CreateObject<DutyCycleAns>());
 }
 
 void
@@ -841,7 +841,7 @@ EndDeviceLorawanMac::OnRxParamSetupReq(Ptr<RxParamSetupReq> rxParamSetupReq)
 }
 
 void
-EndDeviceLorawanMac::OnDevStatusReq(void)
+EndDeviceLorawanMac::OnDevStatusReq()
 {
     NS_LOG_FUNCTION(this);
 
@@ -850,7 +850,7 @@ EndDeviceLorawanMac::OnDevStatusReq(void)
 
     // Craft a RxParamSetupAns as response
     NS_LOG_INFO("Adding DevStatusAns reply");
-    m_macCommandList.push_back(CreateObject<DevStatusAns>(battery, margin));
+    m_macCommandList.emplace_back(CreateObject<DevStatusAns>(battery, margin));
 }
 
 void
@@ -870,7 +870,7 @@ EndDeviceLorawanMac::OnNewChannelReq(uint8_t chIndex,
     SetLogicalChannel(chIndex, frequency, minDataRate, maxDataRate);
 
     NS_LOG_INFO("Adding NewChannelAns reply");
-    m_macCommandList.push_back(CreateObject<NewChannelAns>(dataRateRangeOk, channelFrequencyOk));
+    m_macCommandList.emplace_back(CreateObject<NewChannelAns>(dataRateRangeOk, channelFrequencyOk));
 }
 
 void
@@ -915,7 +915,7 @@ EndDeviceLorawanMac::AddSubBand(double startFrequency,
 }
 
 double
-EndDeviceLorawanMac::GetAggregatedDutyCycle(void)
+EndDeviceLorawanMac::GetAggregatedDutyCycle()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -931,7 +931,7 @@ EndDeviceLorawanMac::AddMacCommand(Ptr<MacCommand> macCommand)
 }
 
 uint8_t
-EndDeviceLorawanMac::GetTransmissionPower(void)
+EndDeviceLorawanMac::GetTransmissionPower()
 {
     return m_txPower;
 }

--- a/model/end-device-lorawan-mac.h
+++ b/model/end-device-lorawan-mac.h
@@ -42,10 +42,10 @@ namespace lorawan
 class EndDeviceLorawanMac : public LorawanMac
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     EndDeviceLorawanMac();
-    virtual ~EndDeviceLorawanMac();
+    ~EndDeviceLorawanMac() override;
 
     /////////////////////
     // Sending methods //
@@ -58,7 +58,7 @@ class EndDeviceLorawanMac : public LorawanMac
      *
      * \param packet the packet to send
      */
-    virtual void Send(Ptr<Packet> packet);
+    void Send(Ptr<Packet> packet) override;
 
     /**
      * Checking if we are performing the transmission of a new packet or a retransmission, and call
@@ -95,16 +95,16 @@ class EndDeviceLorawanMac : public LorawanMac
      *
      * \param packet the received packet.
      */
-    virtual void Receive(Ptr<const Packet> packet);
+    void Receive(Ptr<const Packet> packet) override;
 
-    virtual void FailedReception(Ptr<const Packet> packet);
+    void FailedReception(Ptr<const Packet> packet) override;
 
     /**
      * Perform the actions that are required after a packet send.
      *
      * This function handles opening of the first receive window.
      */
-    virtual void TxFinished(Ptr<const Packet> packet);
+    void TxFinished(Ptr<const Packet> packet) override;
 
     /////////////////////////
     // Getters and Setters //
@@ -125,7 +125,7 @@ class EndDeviceLorawanMac : public LorawanMac
     /**
      * Get if data rate adaptation is enabled or not.
      */
-    bool GetDataRateAdaptation(void);
+    bool GetDataRateAdaptation() const;
 
     /**
      * Set the maximum number of transmissions allowed.
@@ -137,7 +137,7 @@ class EndDeviceLorawanMac : public LorawanMac
     /**
      * Set the maximum number of transmissions allowed.
      */
-    uint8_t GetMaxNumberOfTransmissions(void);
+    uint8_t GetMaxNumberOfTransmissions();
 
     /**
      * Set the data rate this end device will use when transmitting. For End
@@ -153,14 +153,14 @@ class EndDeviceLorawanMac : public LorawanMac
      *
      * \return The data rate this device uses when transmitting.
      */
-    uint8_t GetDataRate(void);
+    uint8_t GetDataRate();
 
     /**
      * Get the transmission power this end device is set to use.
      *
      * \return The transmission power this device uses when transmitting.
      */
-    virtual uint8_t GetTransmissionPower(void);
+    virtual uint8_t GetTransmissionPower();
 
     /**
      * Set the network address of this device.
@@ -174,7 +174,7 @@ class EndDeviceLorawanMac : public LorawanMac
      *
      * \return This device's address.
      */
-    LoraDeviceAddress GetDeviceAddress(void);
+    LoraDeviceAddress GetDeviceAddress();
 
     /**
      * Set a value for the RX1DROffset parameter.
@@ -192,7 +192,7 @@ class EndDeviceLorawanMac : public LorawanMac
      *
      * \return The value of the RX1DROffset parameter.
      */
-    // uint8_t GetRx1DrOffset (void);
+    // uint8_t GetRx1DrOffset ();
 
     /**
      * Get the aggregated duty cycle.
@@ -200,7 +200,7 @@ class EndDeviceLorawanMac : public LorawanMac
      * \return A time instance containing the aggregated duty cycle in fractional
      * form.
      */
-    double GetAggregatedDutyCycle(void);
+    double GetAggregatedDutyCycle();
 
     /////////////////////////
     // MAC command methods //
@@ -228,7 +228,7 @@ class EndDeviceLorawanMac : public LorawanMac
     /**
      * Get the message type to send when the Send method is called.
      */
-    LorawanMacHeader::MType GetMType(void);
+    LorawanMacHeader::MType GetMType();
 
     /**
      * Parse and take action on the commands contained on this FrameHeader.
@@ -282,7 +282,7 @@ class EndDeviceLorawanMac : public LorawanMac
     /**
      * Perform the actions that need to be taken when receiving a DevStatusReq command.
      */
-    void OnDevStatusReq(void);
+    void OnDevStatusReq();
 
     /**
      * Perform the actions that need to be taken when receiving a NewChannelReq command.
@@ -350,7 +350,7 @@ class EndDeviceLorawanMac : public LorawanMac
     struct LoraRetxParameters
     {
         Time firstAttempt;
-        Ptr<Packet> packet = 0;
+        Ptr<Packet> packet = nullptr;
         bool waitingAck = false;
         uint8_t retxLeft;
     };
@@ -401,7 +401,7 @@ class EndDeviceLorawanMac : public LorawanMac
      * ones that are available in the ED's LogicalLoraChannel, based on their duty
      * cycle limitations.
      */
-    Ptr<LogicalLoraChannel> GetChannelForTx(void);
+    Ptr<LogicalLoraChannel> GetChannelForTx();
 
     /**
      * The duration of a receive window in number of symbols. This should be
@@ -453,7 +453,7 @@ class EndDeviceLorawanMac : public LorawanMac
     /**
      * Find the minimum waiting time before the next possible transmission.
      */
-    Time GetNextTransmissionDelay(void);
+    Time GetNextTransmissionDelay();
 
     /**
      * Whether this device's data rate should be controlled by the NS.

--- a/model/end-device-status.cc
+++ b/model/end-device-status.cc
@@ -40,7 +40,7 @@ namespace lorawan
 NS_LOG_COMPONENT_DEFINE("EndDeviceStatus");
 
 TypeId
-EndDeviceStatus::GetTypeId(void)
+EndDeviceStatus::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::EndDeviceStatus")
                             .SetParent<Object>()
@@ -78,7 +78,7 @@ EndDeviceStatus::~EndDeviceStatus()
 ///////////////
 
 uint8_t
-EndDeviceStatus::GetFirstReceiveWindowSpreadingFactor()
+EndDeviceStatus::GetFirstReceiveWindowSpreadingFactor() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -86,7 +86,7 @@ EndDeviceStatus::GetFirstReceiveWindowSpreadingFactor()
 }
 
 double
-EndDeviceStatus::GetFirstReceiveWindowFrequency()
+EndDeviceStatus::GetFirstReceiveWindowFrequency() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -94,7 +94,7 @@ EndDeviceStatus::GetFirstReceiveWindowFrequency()
 }
 
 uint8_t
-EndDeviceStatus::GetSecondReceiveWindowOffset()
+EndDeviceStatus::GetSecondReceiveWindowOffset() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -102,14 +102,14 @@ EndDeviceStatus::GetSecondReceiveWindowOffset()
 }
 
 double
-EndDeviceStatus::GetSecondReceiveWindowFrequency()
+EndDeviceStatus::GetSecondReceiveWindowFrequency() const
 {
     NS_LOG_FUNCTION_NOARGS();
     return m_secondReceiveWindowFrequency;
 }
 
 Ptr<Packet>
-EndDeviceStatus::GetCompleteReplyPacket(void)
+EndDeviceStatus::GetCompleteReplyPacket()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -146,7 +146,7 @@ EndDeviceStatus::GetCompleteReplyPacket(void)
 }
 
 bool
-EndDeviceStatus::NeedsReply(void)
+EndDeviceStatus::NeedsReply() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -154,34 +154,34 @@ EndDeviceStatus::NeedsReply(void)
 }
 
 LorawanMacHeader
-EndDeviceStatus::GetReplyMacHeader()
+EndDeviceStatus::GetReplyMacHeader() const
 {
     NS_LOG_FUNCTION_NOARGS();
     return m_reply.macHeader;
 }
 
 LoraFrameHeader
-EndDeviceStatus::GetReplyFrameHeader()
+EndDeviceStatus::GetReplyFrameHeader() const
 {
     NS_LOG_FUNCTION_NOARGS();
     return m_reply.frameHeader;
 }
 
 Ptr<Packet>
-EndDeviceStatus::GetReplyPayload(void)
+EndDeviceStatus::GetReplyPayload()
 {
     NS_LOG_FUNCTION_NOARGS();
     return m_reply.payload->Copy();
 }
 
 Ptr<ClassAEndDeviceLorawanMac>
-EndDeviceStatus::GetMac(void)
+EndDeviceStatus::GetMac()
 {
     return m_mac;
 }
 
 EndDeviceStatus::ReceivedPacketList
-EndDeviceStatus::GetReceivedPacketList()
+EndDeviceStatus::GetReceivedPacketList() const
 {
     NS_LOG_FUNCTION_NOARGS();
     return m_receivedPacketList;
@@ -317,14 +317,13 @@ EndDeviceStatus::InsertReceivedPacket(Ptr<const Packet> receivedPacket, const Ad
         gwInfo.rxPower = rcvPower;
         gwInfo.gwAddress = gwAddress;
         info.gwList.insert(std::pair<Address, PacketInfoPerGw>(gwAddress, gwInfo));
-        m_receivedPacketList.push_back(
-            std::pair<Ptr<const Packet>, ReceivedPacketInfo>(receivedPacket, info));
+        m_receivedPacketList.emplace_back(receivedPacket, info);
     }
     NS_LOG_DEBUG(*this);
 }
 
 EndDeviceStatus::ReceivedPacketInfo
-EndDeviceStatus::GetLastReceivedPacketInfo(void)
+EndDeviceStatus::GetLastReceivedPacketInfo()
 {
     NS_LOG_FUNCTION_NOARGS();
     auto it = m_receivedPacketList.rbegin();
@@ -339,7 +338,7 @@ EndDeviceStatus::GetLastReceivedPacketInfo(void)
 }
 
 Ptr<const Packet>
-EndDeviceStatus::GetLastPacketReceivedFromDevice(void)
+EndDeviceStatus::GetLastPacketReceivedFromDevice()
 {
     NS_LOG_FUNCTION_NOARGS();
     auto it = m_receivedPacketList.rbegin();
@@ -349,7 +348,7 @@ EndDeviceStatus::GetLastPacketReceivedFromDevice(void)
     }
     else
     {
-        return 0;
+        return nullptr;
     }
 }
 
@@ -380,13 +379,13 @@ EndDeviceStatus::SetReceiveWindowOpportunity(EventId event)
 }
 
 void
-EndDeviceStatus::RemoveReceiveWindowOpportunity(void)
+EndDeviceStatus::RemoveReceiveWindowOpportunity()
 {
     Simulator::Cancel(m_receiveWindowEvent);
 }
 
 std::map<double, Address>
-EndDeviceStatus::GetPowerGatewayMap(void)
+EndDeviceStatus::GetPowerGatewayMap()
 {
     // Create a map of the gateways
     // Key: received power
@@ -417,8 +416,7 @@ operator<<(std::ostream& os, const EndDeviceStatus& status)
         EndDeviceStatus::GatewayList gatewayList = info.gwList;
         Ptr<const Packet> pkt = (*j).first;
         os << pkt << " " << gatewayList.size() << std::endl;
-        for (EndDeviceStatus::GatewayList::iterator k = gatewayList.begin(); k != gatewayList.end();
-             k++)
+        for (auto k = gatewayList.begin(); k != gatewayList.end(); k++)
         {
             EndDeviceStatus::PacketInfoPerGw infoPerGw = (*k).second;
             os << "  " << infoPerGw.gwAddress << " " << infoPerGw.rxPower << std::endl;

--- a/model/end-device-status.h
+++ b/model/end-device-status.h
@@ -115,35 +115,35 @@ class EndDeviceStatus : public Object
      *
      * \return A boolean value signaling if the end device needs a reply.
      */
-    bool NeedsReply(void);
+    bool NeedsReply() const;
 
     /**
      * Get the reply packet.
      *
      * \return A pointer to the packet reply (data + headers).
      */
-    Ptr<Packet> GetCompleteReplyPacket(void);
+    Ptr<Packet> GetCompleteReplyPacket();
 
     /**
      * Get the reply packet mac header.
      *
      * \return The packet reply mac header.
      */
-    LorawanMacHeader GetReplyMacHeader(void);
+    LorawanMacHeader GetReplyMacHeader() const;
 
     /**
      * Get the reply packet frame header.
      *
      * \return The packet reply frame header.
      */
-    LoraFrameHeader GetReplyFrameHeader(void);
+    LoraFrameHeader GetReplyFrameHeader() const;
 
     /**
      * Get the data of the reply packet.
      *
      * \return A pointer to the packet reply.
      */
-    Ptr<Packet> GetReplyPayload(void);
+    Ptr<Packet> GetReplyPayload();
 
     /***********************************/
     /* Received packet list management */
@@ -169,8 +169,8 @@ class EndDeviceStatus : public Object
     struct ReceivedPacketInfo
     {
         // Members
-        Ptr<const Packet> packet = 0; //!< The received packet
-        GatewayList gwList;           //!< List of gateways that received this packet.
+        Ptr<const Packet> packet = nullptr; //!< The received packet
+        GatewayList gwList;                 //!< List of gateways that received this packet.
         uint8_t sf;
         double frequency;
     };
@@ -181,24 +181,24 @@ class EndDeviceStatus : public Object
     /* Proper EndDeviceStatus class definition */
     /*******************************************/
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     EndDeviceStatus();
     EndDeviceStatus(LoraDeviceAddress endDeviceAddress,
                     Ptr<ClassAEndDeviceLorawanMac> endDeviceMac);
-    virtual ~EndDeviceStatus();
+    ~EndDeviceStatus() override;
 
     /**
      * Get the spreading factor this device is using in the first receive window.
      *
      * \return An unsigned 8-bit integer containing the spreading factor.
      */
-    uint8_t GetFirstReceiveWindowSpreadingFactor(void);
+    uint8_t GetFirstReceiveWindowSpreadingFactor() const;
 
     /**
      * Get the first window frequency of this device.
      */
-    double GetFirstReceiveWindowFrequency(void);
+    double GetFirstReceiveWindowFrequency() const;
 
     /**
      * Get the offset of spreading factor this device is using in the second
@@ -206,20 +206,20 @@ class EndDeviceStatus : public Object
      *
      * \return An unsigned 8-bit integer containing the spreading factor.
      */
-    uint8_t GetSecondReceiveWindowOffset(void);
+    uint8_t GetSecondReceiveWindowOffset() const;
 
     /**
      * Return the second window frequency of this device.
      *
      */
-    double GetSecondReceiveWindowFrequency(void);
+    double GetSecondReceiveWindowFrequency() const;
 
     /**
      * Get the received packet list.
      *
      * \return The received packet list.
      */
-    ReceivedPacketList GetReceivedPacketList(void);
+    ReceivedPacketList GetReceivedPacketList() const;
 
     /**
      * Set the spreading factor this device is using in the first receive window.
@@ -256,7 +256,7 @@ class EndDeviceStatus : public Object
      */
     void SetReplyPayload(Ptr<Packet> replyPayload);
 
-    Ptr<ClassAEndDeviceLorawanMac> GetMac(void);
+    Ptr<ClassAEndDeviceLorawanMac> GetMac();
 
     //////////////////////
     //  Other methods  //
@@ -270,18 +270,18 @@ class EndDeviceStatus : public Object
     /**
      * Return the last packet that was received from this device.
      */
-    Ptr<const Packet> GetLastPacketReceivedFromDevice(void);
+    Ptr<const Packet> GetLastPacketReceivedFromDevice();
 
     /**
      * Return the information about the last packet that was received from the
      * device.
      */
-    EndDeviceStatus::ReceivedPacketInfo GetLastReceivedPacketInfo(void);
+    EndDeviceStatus::ReceivedPacketInfo GetLastReceivedPacketInfo();
 
     /**
      * Initialize reply.
      */
-    void InitializeReply(void);
+    void InitializeReply();
 
     /**
      * Add MAC command to the list.
@@ -300,12 +300,12 @@ class EndDeviceStatus : public Object
 
     void SetReceiveWindowOpportunity(EventId event);
 
-    void RemoveReceiveWindowOpportunity(void);
+    void RemoveReceiveWindowOpportunity();
 
     /**
      * Return an ordered list of the best gateways.
      */
-    std::map<double, Address> GetPowerGatewayMap(void);
+    std::map<double, Address> GetPowerGatewayMap();
 
     struct Reply m_reply; //<! Next reply intended for this device
 

--- a/model/forwarder.cc
+++ b/model/forwarder.cc
@@ -31,7 +31,7 @@ NS_LOG_COMPONENT_DEFINE("Forwarder");
 NS_OBJECT_ENSURE_REGISTERED(Forwarder);
 
 TypeId
-Forwarder::GetTypeId(void)
+Forwarder::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::Forwarder")
                             .SetParent<Application>()
@@ -97,7 +97,7 @@ Forwarder::ReceiveFromPointToPoint(Ptr<NetDevice> pointToPointNetDevice,
 }
 
 void
-Forwarder::StartApplication(void)
+Forwarder::StartApplication()
 {
     NS_LOG_FUNCTION(this);
 
@@ -105,7 +105,7 @@ Forwarder::StartApplication(void)
 }
 
 void
-Forwarder::StopApplication(void)
+Forwarder::StopApplication()
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/forwarder.h
+++ b/model/forwarder.h
@@ -40,9 +40,9 @@ class Forwarder : public Application
 {
   public:
     Forwarder();
-    ~Forwarder();
+    ~Forwarder() override;
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     /**
      * Sets the device to use to communicate with the EDs.
@@ -83,12 +83,12 @@ class Forwarder : public Application
     /**
      * Start the application
      */
-    void StartApplication(void);
+    void StartApplication() override;
 
     /**
      * Stop the application
      */
-    void StopApplication(void);
+    void StopApplication() override;
 
   private:
     Ptr<LoraNetDevice> m_loraNetDevice; //!< Pointer to the node's LoraNetDevice

--- a/model/gateway-lora-phy.cc
+++ b/model/gateway-lora-phy.cc
@@ -38,29 +38,29 @@ NS_OBJECT_ENSURE_REGISTERED(GatewayLoraPhy);
  *    ReceptionPath implementation    *
  **************************************/
 GatewayLoraPhy::ReceptionPath::ReceptionPath()
-    : m_available(1),
-      m_event(0),
+    : m_available(true),
+      m_event(nullptr),
       m_endReceiveEventId(EventId())
 {
     NS_LOG_FUNCTION_NOARGS();
 }
 
-GatewayLoraPhy::ReceptionPath::~ReceptionPath(void)
+GatewayLoraPhy::ReceptionPath::~ReceptionPath()
 {
     NS_LOG_FUNCTION_NOARGS();
 }
 
 bool
-GatewayLoraPhy::ReceptionPath::IsAvailable(void)
+GatewayLoraPhy::ReceptionPath::IsAvailable() const
 {
     return m_available;
 }
 
 void
-GatewayLoraPhy::ReceptionPath::Free(void)
+GatewayLoraPhy::ReceptionPath::Free()
 {
     m_available = true;
-    m_event = 0;
+    m_event = nullptr;
     m_endReceiveEventId = EventId();
 }
 
@@ -78,13 +78,13 @@ GatewayLoraPhy::ReceptionPath::SetEvent(Ptr<LoraInterferenceHelper::Event> event
 }
 
 Ptr<LoraInterferenceHelper::Event>
-GatewayLoraPhy::ReceptionPath::GetEvent(void)
+GatewayLoraPhy::ReceptionPath::GetEvent()
 {
     return m_event;
 }
 
 EventId
-GatewayLoraPhy::ReceptionPath::GetEndReceive(void)
+GatewayLoraPhy::ReceptionPath::GetEndReceive()
 {
     return m_endReceiveEventId;
 }
@@ -100,7 +100,7 @@ GatewayLoraPhy::ReceptionPath::SetEndReceive(EventId endReceiveEventId)
  ***********************************************************************/
 
 TypeId
-GatewayLoraPhy::GetTypeId(void)
+GatewayLoraPhy::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::GatewayLoraPhy")
@@ -150,7 +150,7 @@ GatewayLoraPhy::AddReceptionPath()
 }
 
 void
-GatewayLoraPhy::ResetReceptionPaths(void)
+GatewayLoraPhy::ResetReceptionPaths()
 {
     NS_LOG_FUNCTION(this);
 
@@ -164,7 +164,7 @@ GatewayLoraPhy::TxFinished(Ptr<Packet> packet)
 }
 
 bool
-GatewayLoraPhy::IsTransmitting(void)
+GatewayLoraPhy::IsTransmitting()
 {
     return m_isTransmitting;
 }

--- a/model/gateway-lora-phy.h
+++ b/model/gateway-lora-phy.h
@@ -51,29 +51,29 @@ class LoraChannel;
 class GatewayLoraPhy : public LoraPhy
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     GatewayLoraPhy();
-    virtual ~GatewayLoraPhy();
+    ~GatewayLoraPhy() override;
 
-    virtual void StartReceive(Ptr<Packet> packet,
-                              double rxPowerDbm,
-                              uint8_t sf,
-                              Time duration,
-                              double frequencyMHz) = 0;
+    void StartReceive(Ptr<Packet> packet,
+                      double rxPowerDbm,
+                      uint8_t sf,
+                      Time duration,
+                      double frequencyMHz) override = 0;
 
-    virtual void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) = 0;
+    void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) override = 0;
 
-    virtual void Send(Ptr<Packet> packet,
-                      LoraTxParameters txParams,
-                      double frequencyMHz,
-                      double txPowerDbm) = 0;
+    void Send(Ptr<Packet> packet,
+              LoraTxParameters txParams,
+              double frequencyMHz,
+              double txPowerDbm) override = 0;
 
     virtual void TxFinished(Ptr<Packet> packet);
 
-    bool IsTransmitting(void);
+    bool IsTransmitting() override;
 
-    virtual bool IsOnFrequency(double frequencyMHz);
+    bool IsOnFrequency(double frequencyMHz) override;
 
     /**
      * Add a reception path, locked on a specific frequency.
@@ -85,7 +85,7 @@ class GatewayLoraPhy : public LoraPhy
      *
      * This method deletes all currently available ReceptionPath objects.
      */
-    void ResetReceptionPaths(void);
+    void ResetReceptionPaths();
 
     /**
      * Add a frequency to the list of frequencies we are listening to.
@@ -121,7 +121,7 @@ class GatewayLoraPhy : public LoraPhy
          *
          * \return True if its current state is free, false if it's currently locked.
          */
-        bool IsAvailable(void);
+        bool IsAvailable() const;
 
         /**
          * Set this reception path as available.
@@ -129,7 +129,7 @@ class GatewayLoraPhy : public LoraPhy
          * This function sets the m_available variable as true, and deletes the
          * LoraInterferenceHelper Event this ReceivePath was previously locked on.
          */
-        void Free(void);
+        void Free();
 
         /**
          * Set this reception path as not available and lock it on the
@@ -152,13 +152,13 @@ class GatewayLoraPhy : public LoraPhy
          * \returns 0 if no event is currently being received, a pointer to
          * the event otherwise.
          */
-        Ptr<LoraInterferenceHelper::Event> GetEvent(void);
+        Ptr<LoraInterferenceHelper::Event> GetEvent();
 
         /**
          * Get the EventId of the EndReceive call associated to this ReceptionPath's
          * packet.
          */
-        EventId GetEndReceive(void);
+        EventId GetEndReceive();
 
         /**
          * Set the EventId of the EndReceive call associated to this ReceptionPath's

--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -35,7 +35,7 @@ NS_LOG_COMPONENT_DEFINE("GatewayLorawanMac");
 NS_OBJECT_ENSURE_REGISTERED(GatewayLorawanMac);
 
 TypeId
-GatewayLorawanMac::GetTypeId(void)
+GatewayLorawanMac::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::GatewayLorawanMac")
                             .SetParent<LorawanMac>()
@@ -84,9 +84,8 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     params.codingRate = 1;
     params.bandwidthHz = GetBandwidthFromDataRate(dataRate);
     params.nPreamble = 8;
-    params.crcEnabled = 1;
-    params.lowDataRateOptimizationEnabled =
-        LoraPhy::GetTSym(params) > MilliSeconds(16) ? true : false;
+    params.crcEnabled = true;
+    params.lowDataRateOptimizationEnabled = LoraPhy::GetTSym(params) > MilliSeconds(16);
 
     // Get the duration
     Time duration = m_phy->GetOnAirTime(packet, params);
@@ -107,7 +106,7 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
 }
 
 bool
-GatewayLorawanMac::IsTransmitting(void)
+GatewayLorawanMac::IsTransmitting()
 {
     return m_phy->IsTransmitting();
 }

--- a/model/gateway-lorawan-mac.h
+++ b/model/gateway-lorawan-mac.h
@@ -31,25 +31,25 @@ namespace lorawan
 class GatewayLorawanMac : public LorawanMac
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     GatewayLorawanMac();
-    virtual ~GatewayLorawanMac();
+    ~GatewayLorawanMac() override;
 
     // Implementation of the LorawanMac interface
-    virtual void Send(Ptr<Packet> packet);
+    void Send(Ptr<Packet> packet) override;
 
     // Implementation of the LorawanMac interface
-    bool IsTransmitting(void);
+    bool IsTransmitting();
 
     // Implementation of the LorawanMac interface
-    virtual void Receive(Ptr<const Packet> packet);
+    void Receive(Ptr<const Packet> packet) override;
 
     // Implementation of the LorawanMac interface
-    virtual void FailedReception(Ptr<const Packet> packet);
+    void FailedReception(Ptr<const Packet> packet) override;
 
     // Implementation of the LorawanMac interface
-    virtual void TxFinished(Ptr<const Packet> packet);
+    void TxFinished(Ptr<const Packet> packet) override;
 
     /**
      * Return the next time at which we will be able to transmit.

--- a/model/gateway-status.cc
+++ b/model/gateway-status.cc
@@ -29,7 +29,7 @@ namespace lorawan
 NS_LOG_COMPONENT_DEFINE("GatewayStatus");
 
 TypeId
-GatewayStatus::GetTypeId(void)
+GatewayStatus::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::GatewayStatus").AddConstructor<GatewayStatus>().SetGroupName("lorawan");
@@ -86,7 +86,7 @@ GatewayStatus::SetNetDevice(Ptr<NetDevice> netDevice)
 }
 
 Ptr<GatewayLorawanMac>
-GatewayStatus::GetGatewayMac(void)
+GatewayStatus::GetGatewayMac()
 {
     return m_gatewayMac;
 }

--- a/model/gateway-status.h
+++ b/model/gateway-status.h
@@ -34,11 +34,11 @@ namespace lorawan
 class GatewayStatus : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     GatewayStatus();
     GatewayStatus(Address address, Ptr<NetDevice> netDevice, Ptr<GatewayLorawanMac> gwMac);
-    virtual ~GatewayStatus();
+    ~GatewayStatus() override;
 
     /**
      * Get this gateway's P2P link address.
@@ -63,7 +63,7 @@ class GatewayStatus : public Object
     /**
      * Get a pointer to this gateway's MAC instance.
      */
-    Ptr<GatewayLorawanMac> GetGatewayMac(void);
+    Ptr<GatewayLorawanMac> GetGatewayMac();
 
     /**
      * Set a pointer to this gateway's MAC instance.
@@ -81,7 +81,7 @@ class GatewayStatus : public Object
     bool IsAvailableForTransmission(double frequency);
 
     void SetNextTransmissionTime(Time nextTransmissionTime);
-    // Time GetNextTransmissionTime (void);
+    // Time GetNextTransmissionTime ();
 
   private:
     Address m_address; //!< The Address of the P2PNetDevice of this gateway

--- a/model/hex-grid-position-allocator.cc
+++ b/model/hex-grid-position-allocator.cc
@@ -28,7 +28,7 @@ NS_LOG_COMPONENT_DEFINE("HexGridPositionAllocator");
 NS_OBJECT_ENSURE_REGISTERED(HexGridPositionAllocator);
 
 TypeId
-HexGridPositionAllocator::GetTypeId(void)
+HexGridPositionAllocator::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::HexGridPositionAllocator")
                             .SetParent<PositionAllocator>()
@@ -49,7 +49,7 @@ HexGridPositionAllocator::HexGridPositionAllocator()
     NS_LOG_FUNCTION_NOARGS();
 
     // Create the first position
-    m_positions.push_back(Vector(0.0, 0.0, 0.0));
+    m_positions.emplace_back(0.0, 0.0, 0.0);
 
     // Add rings
     for (int i = 0; i < 20; i++)
@@ -67,7 +67,7 @@ HexGridPositionAllocator::HexGridPositionAllocator(double radius)
     NS_LOG_FUNCTION_NOARGS();
 
     // Create the first position
-    m_positions.push_back(Vector(0.0, 0.0, 0.0));
+    m_positions.emplace_back(0.0, 0.0, 0.0);
 
     // Add a couple rings
     // Add rings
@@ -88,7 +88,7 @@ HexGridPositionAllocator::~HexGridPositionAllocator()
 const double HexGridPositionAllocator::pi = std::acos(-1);
 
 double
-HexGridPositionAllocator::GetRadius(void)
+HexGridPositionAllocator::GetRadius() const
 {
     return m_radius;
 }
@@ -100,7 +100,7 @@ HexGridPositionAllocator::SetRadius(double radius)
 }
 
 Vector
-HexGridPositionAllocator::GetNext(void) const
+HexGridPositionAllocator::GetNext() const
 {
     // TODO: Check that there is a next element
     Vector position = *m_next;
@@ -123,7 +123,7 @@ HexGridPositionAllocator::AddRing(std::vector<Vector> positions)
     std::vector<Vector> copy = positions;
 
     // Iterate on the given vector
-    for (std::vector<Vector>::iterator it = positions.begin(); it != positions.end(); it++)
+    for (auto it = positions.begin(); it != positions.end(); it++)
     {
         // Get the current position
         Vector currentPosition = *it;
@@ -141,7 +141,7 @@ HexGridPositionAllocator::AddRing(std::vector<Vector> positions)
 
             // If the newly created position is not already in the copy, add it
             bool found = false;
-            for (std::vector<Vector>::iterator it = copy.begin(); it != copy.end(); it++)
+            for (auto it = copy.begin(); it != copy.end(); it++)
             {
                 // If the vector is already in the vector
                 // 1 is an EPSILON used to determine whether two floats are equal
@@ -151,7 +151,7 @@ HexGridPositionAllocator::AddRing(std::vector<Vector> positions)
                     break;
                 }
             }
-            if (found == false)
+            if (!found)
             {
                 NS_LOG_DEBUG("Adding position " << newPosition);
                 copy.push_back(newPosition);

--- a/model/hex-grid-position-allocator.h
+++ b/model/hex-grid-position-allocator.h
@@ -31,15 +31,15 @@ class HexGridPositionAllocator : public PositionAllocator
     HexGridPositionAllocator();
     HexGridPositionAllocator(double radius);
 
-    ~HexGridPositionAllocator();
+    ~HexGridPositionAllocator() override;
 
-    virtual Vector GetNext(void) const;
+    Vector GetNext() const override;
 
-    virtual int64_t AssignStreams(int64_t stream);
+    int64_t AssignStreams(int64_t stream) override;
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
-    double GetRadius(void);
+    double GetRadius() const;
 
     void SetRadius(double radius);
 

--- a/model/logical-lora-channel-helper.cc
+++ b/model/logical-lora-channel-helper.cc
@@ -32,7 +32,7 @@ NS_LOG_COMPONENT_DEFINE("LogicalLoraChannelHelper");
 NS_OBJECT_ENSURE_REGISTERED(LogicalLoraChannelHelper);
 
 TypeId
-LogicalLoraChannelHelper::GetTypeId(void)
+LogicalLoraChannelHelper::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LogicalLoraChannelHelper").SetParent<Object>().SetGroupName("lorawan");
@@ -52,7 +52,7 @@ LogicalLoraChannelHelper::~LogicalLoraChannelHelper()
 }
 
 std::vector<Ptr<LogicalLoraChannel>>
-LogicalLoraChannelHelper::GetChannelList(void)
+LogicalLoraChannelHelper::GetChannelList()
 {
     NS_LOG_FUNCTION(this);
 
@@ -65,7 +65,7 @@ LogicalLoraChannelHelper::GetChannelList(void)
 }
 
 std::vector<Ptr<LogicalLoraChannel>>
-LogicalLoraChannelHelper::GetEnabledChannelList(void)
+LogicalLoraChannelHelper::GetEnabledChannelList()
 {
     NS_LOG_FUNCTION(this);
 
@@ -111,7 +111,7 @@ LogicalLoraChannelHelper::GetSubBandFromFrequency(double frequency)
     NS_LOG_ERROR("Requested frequency: " << frequency);
     NS_ABORT_MSG("Warning: frequency is outside any known SubBand.");
 
-    return 0; // If no SubBand is found, return 0
+    return nullptr; // If no SubBand is found, return 0
 }
 
 void
@@ -184,7 +184,7 @@ LogicalLoraChannelHelper::RemoveChannel(Ptr<LogicalLoraChannel> logicalChannel)
 }
 
 Time
-LogicalLoraChannelHelper::GetAggregatedWaitingTime(void)
+LogicalLoraChannelHelper::GetAggregatedWaitingTime()
 {
     // Aggregate waiting time
     Time aggregatedWaitingTime = m_nextAggregatedTransmissionTime - Simulator::Now();

--- a/model/logical-lora-channel-helper.h
+++ b/model/logical-lora-channel-helper.h
@@ -48,10 +48,10 @@ namespace lorawan
 class LogicalLoraChannelHelper : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     LogicalLoraChannelHelper();
-    virtual ~LogicalLoraChannelHelper();
+    ~LogicalLoraChannelHelper() override;
 
     /**
      * Get the time it is necessary to wait before transmitting again, according
@@ -59,7 +59,7 @@ class LogicalLoraChannelHelper : public Object
      *
      * \return The aggregate waiting time.
      */
-    Time GetAggregatedWaitingTime(void);
+    Time GetAggregatedWaitingTime();
 
     /**
      * Get the time it is necessary to wait for before transmitting on a given
@@ -88,7 +88,7 @@ class LogicalLoraChannelHelper : public Object
      *
      * \return A list of the managed channels.
      */
-    std::vector<Ptr<LogicalLoraChannel>> GetChannelList(void);
+    std::vector<Ptr<LogicalLoraChannel>> GetChannelList();
 
     /**
      * Get the list of LogicalLoraChannels currently registered on this helper
@@ -96,7 +96,7 @@ class LogicalLoraChannelHelper : public Object
      *
      * \return A list of the managed channels enabled for Uplink transmission.
      */
-    std::vector<Ptr<LogicalLoraChannel>> GetEnabledChannelList(void);
+    std::vector<Ptr<LogicalLoraChannel>> GetEnabledChannelList();
 
     /**
      * Add a new channel to the list.

--- a/model/logical-lora-channel.cc
+++ b/model/logical-lora-channel.cc
@@ -31,7 +31,7 @@ NS_LOG_COMPONENT_DEFINE("LogicalLoraChannel");
 NS_OBJECT_ENSURE_REGISTERED(LogicalLoraChannel);
 
 TypeId
-LogicalLoraChannel::GetTypeId(void)
+LogicalLoraChannel::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LogicalLoraChannel").SetParent<Object>().SetGroupName("lorawan");
@@ -69,7 +69,7 @@ LogicalLoraChannel::LogicalLoraChannel(double frequency, uint8_t minDataRate, ui
 }
 
 double
-LogicalLoraChannel::GetFrequency(void) const
+LogicalLoraChannel::GetFrequency() const
 {
     return m_frequency;
 }
@@ -87,31 +87,31 @@ LogicalLoraChannel::SetMaximumDataRate(uint8_t maxDataRate)
 }
 
 uint8_t
-LogicalLoraChannel::GetMinimumDataRate(void)
+LogicalLoraChannel::GetMinimumDataRate() const
 {
     return m_minDataRate;
 }
 
 uint8_t
-LogicalLoraChannel::GetMaximumDataRate(void)
+LogicalLoraChannel::GetMaximumDataRate() const
 {
     return m_maxDataRate;
 }
 
 void
-LogicalLoraChannel::SetEnabledForUplink(void)
+LogicalLoraChannel::SetEnabledForUplink()
 {
     m_enabledForUplink = true;
 }
 
 void
-LogicalLoraChannel::DisableForUplink(void)
+LogicalLoraChannel::DisableForUplink()
 {
     m_enabledForUplink = false;
 }
 
 bool
-LogicalLoraChannel::IsEnabledForUplink(void)
+LogicalLoraChannel::IsEnabledForUplink() const
 {
     return m_enabledForUplink;
 }

--- a/model/logical-lora-channel.h
+++ b/model/logical-lora-channel.h
@@ -43,10 +43,10 @@ class SubBand;
 class LogicalLoraChannel : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     LogicalLoraChannel();
-    virtual ~LogicalLoraChannel();
+    ~LogicalLoraChannel() override;
 
     LogicalLoraChannel(double frequency);
 
@@ -64,7 +64,7 @@ class LogicalLoraChannel : public Object
      *
      * \return The center frequency of this channel.
      */
-    double GetFrequency(void) const;
+    double GetFrequency() const;
 
     /**
      * Set the frequency (MHz).
@@ -86,27 +86,27 @@ class LogicalLoraChannel : public Object
     /**
      * Get the minimum Data Rate that is allowed on this channel.
      */
-    uint8_t GetMinimumDataRate(void);
+    uint8_t GetMinimumDataRate() const;
 
     /**
      * Get the maximum Data Rate that is allowed on this channel.
      */
-    uint8_t GetMaximumDataRate(void);
+    uint8_t GetMaximumDataRate() const;
 
     /**
      * Set this channel as enabled for uplink.
      */
-    void SetEnabledForUplink(void);
+    void SetEnabledForUplink();
 
     /**
      * Set this channel as disabled for uplink.
      */
-    void DisableForUplink(void);
+    void DisableForUplink();
 
     /**
      * Test whether this channel is marked as enabled for uplink.
      */
-    bool IsEnabledForUplink(void);
+    bool IsEnabledForUplink() const;
 
   private:
     /**

--- a/model/lora-channel.cc
+++ b/model/lora-channel.cc
@@ -40,7 +40,7 @@ NS_LOG_COMPONENT_DEFINE("LoraChannel");
 NS_OBJECT_ENSURE_REGISTERED(LoraChannel);
 
 TypeId
-LoraChannel::GetTypeId(void)
+LoraChannel::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LoraChannel")
@@ -98,7 +98,7 @@ LoraChannel::Remove(Ptr<LoraPhy> phy)
 }
 
 std::size_t
-LoraChannel::GetNDevices(void) const
+LoraChannel::GetNDevices() const
 {
     return m_phyList.size();
 }

--- a/model/lora-channel.h
+++ b/model/lora-channel.h
@@ -78,15 +78,15 @@ class LoraChannel : public Channel
 {
   public:
     // TypeId
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     // Constructor and destructor
     LoraChannel();
-    virtual ~LoraChannel();
+    ~LoraChannel() override;
 
     // Inherited from Channel.
-    virtual std::size_t GetNDevices(void) const;
-    virtual Ptr<NetDevice> GetDevice(std::size_t i) const;
+    std::size_t GetNDevices() const override;
+    Ptr<NetDevice> GetDevice(std::size_t i) const override;
 
     /**
      * Construct a LoraChannel with a loss and delay model.

--- a/model/lora-device-address-generator.cc
+++ b/model/lora-device-address-generator.cc
@@ -29,7 +29,7 @@ namespace lorawan
 NS_LOG_COMPONENT_DEFINE("LoraDeviceAddressGenerator");
 
 TypeId
-LoraDeviceAddressGenerator::GetTypeId(void)
+LoraDeviceAddressGenerator::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::LoraDeviceAddressGenerator")
                             .SetParent<Object>()
@@ -47,7 +47,7 @@ LoraDeviceAddressGenerator::LoraDeviceAddressGenerator(const uint8_t nwkId, cons
 }
 
 LoraDeviceAddress
-LoraDeviceAddressGenerator::NextNetwork(void)
+LoraDeviceAddressGenerator::NextNetwork()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -58,7 +58,7 @@ LoraDeviceAddressGenerator::NextNetwork(void)
 }
 
 LoraDeviceAddress
-LoraDeviceAddressGenerator::NextAddress(void)
+LoraDeviceAddressGenerator::NextAddress()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -69,7 +69,7 @@ LoraDeviceAddressGenerator::NextAddress(void)
 }
 
 LoraDeviceAddress
-LoraDeviceAddressGenerator::GetNextAddress(void)
+LoraDeviceAddressGenerator::GetNextAddress()
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/lora-device-address-generator.h
+++ b/model/lora-device-address-generator.h
@@ -35,7 +35,7 @@ namespace lorawan
 class LoraDeviceAddressGenerator : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     /**
      * Initialise the base NwkID and the first NwkAddr to be used by the
@@ -56,7 +56,7 @@ class LoraDeviceAddressGenerator : public Object
      *
      * \return the LoraDeviceAddress address of the next network
      */
-    LoraDeviceAddress NextNetwork(void);
+    LoraDeviceAddress NextNetwork();
 
     /**
      * Allocate the next LoraDeviceAddress.
@@ -68,7 +68,7 @@ class LoraDeviceAddressGenerator : public Object
      *
      * \return the LoraDeviceAddress address
      */
-    LoraDeviceAddress NextAddress(void);
+    LoraDeviceAddress NextAddress();
 
     /**
      * Get the LoraDeviceAddress that will be allocated upon a call to
@@ -79,7 +79,7 @@ class LoraDeviceAddressGenerator : public Object
      *
      * \return the LoraDeviceAddress
      */
-    LoraDeviceAddress GetNextAddress(void);
+    LoraDeviceAddress GetNextAddress();
 
   private:
     NwkID m_currentNwkId;     //!< The current Network Id value

--- a/model/lora-device-address.cc
+++ b/model/lora-device-address.cc
@@ -51,7 +51,7 @@ NwkID::Set(uint8_t nwkId)
 }
 
 uint8_t
-NwkID::Get(void) const
+NwkID::Get() const
 {
     return m_nwkId;
 }
@@ -77,7 +77,7 @@ NwkAddr::Set(uint32_t nwkAddr)
 }
 
 uint32_t
-NwkAddr::Get(void) const
+NwkAddr::Get() const
 {
     return m_nwkAddr;
 }
@@ -145,7 +145,7 @@ LoraDeviceAddress::Deserialize(const uint8_t buf[4])
 }
 
 Address
-LoraDeviceAddress::ConvertTo(void) const
+LoraDeviceAddress::ConvertTo() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -170,7 +170,7 @@ LoraDeviceAddress::ConvertFrom(const Address& address)
 }
 
 uint8_t
-LoraDeviceAddress::GetType(void)
+LoraDeviceAddress::GetType()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -179,12 +179,12 @@ LoraDeviceAddress::GetType(void)
 }
 
 uint32_t
-LoraDeviceAddress::Get(void) const
+LoraDeviceAddress::Get() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
     uint32_t address = 0;
-    uint32_t nwkId = uint32_t(m_nwkId.Get() << 25);
+    uint32_t nwkId = m_nwkId.Get() << 25;
     address |= (m_nwkAddr.Get() | nwkId);
     NS_LOG_DEBUG("m_nwkId + m_nwkAddr = " << std::bitset<32>(address));
 
@@ -201,7 +201,7 @@ LoraDeviceAddress::Set(uint32_t address)
 }
 
 uint8_t
-LoraDeviceAddress::GetNwkID(void)
+LoraDeviceAddress::GetNwkID()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -209,7 +209,7 @@ LoraDeviceAddress::GetNwkID(void)
 }
 
 uint32_t
-LoraDeviceAddress::GetNwkAddr(void)
+LoraDeviceAddress::GetNwkAddr()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -233,7 +233,7 @@ LoraDeviceAddress::SetNwkAddr(uint32_t nwkAddr)
 }
 
 std::string
-LoraDeviceAddress::Print(void) const
+LoraDeviceAddress::Print() const
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/lora-device-address.h
+++ b/model/lora-device-address.h
@@ -53,7 +53,7 @@ class NwkID
      *
      * \return The Network Id.
      */
-    uint8_t Get(void) const;
+    uint8_t Get() const;
 
   private:
     uint8_t m_nwkId; //!< 8-bit integer representation of the network id
@@ -84,7 +84,7 @@ class NwkAddr
      *
      * \return The Network Address.
      */
-    uint32_t Get(void) const;
+    uint32_t Get() const;
 
   private:
     uint32_t m_nwkAddr; //!< 8-bit integer representation of the network id
@@ -146,7 +146,7 @@ class LoraDeviceAddress
     /**
      * Get the address in 32-bit integer form.
      */
-    uint32_t Get(void) const;
+    uint32_t Get() const;
 
     /**
      * Get the NwkID of this device.
@@ -156,7 +156,7 @@ class LoraDeviceAddress
      *
      * \return An 8-bit representation of the Network Id of this Device Address.
      */
-    uint8_t GetNwkID(void);
+    uint8_t GetNwkID();
 
     /**
      * Set the NwkID of this device.
@@ -176,7 +176,7 @@ class LoraDeviceAddress
      *
      * \return A 32-bit representation of the Network Address of this Device Address.
      */
-    uint32_t GetNwkAddr(void);
+    uint32_t GetNwkAddr();
 
     /**
      * Set the NwkAddr of this device.
@@ -193,7 +193,7 @@ class LoraDeviceAddress
      *
      * \return The string containing the network address.
      */
-    std::string Print(void) const;
+    std::string Print() const;
 
     bool operator==(const LoraDeviceAddress& other) const;
     bool operator!=(const LoraDeviceAddress& other) const;
@@ -204,8 +204,8 @@ class LoraDeviceAddress
     /**
      * Convert this instance of LoraDeviceAddress to an Address
      */
-    Address ConvertTo(void) const;
-    static uint8_t GetType(void);
+    Address ConvertTo() const;
+    static uint8_t GetType();
     NwkID m_nwkId;     //!< The network Id of this address
     NwkAddr m_nwkAddr; //!< The network address of this address
 };

--- a/model/lora-frame-header.cc
+++ b/model/lora-frame-header.cc
@@ -34,10 +34,10 @@ NS_LOG_COMPONENT_DEFINE("LoraFrameHeader");
 LoraFrameHeader::LoraFrameHeader()
     : m_fPort(0),
       m_address(LoraDeviceAddress(0, 0)),
-      m_adr(0),
-      m_adrAckReq(0),
-      m_ack(0),
-      m_fPending(0),
+      m_adr(false),
+      m_adrAckReq(false),
+      m_ack(false),
+      m_fPending(false),
       m_fOptsLen(0),
       m_fCnt(0)
 {
@@ -48,7 +48,7 @@ LoraFrameHeader::~LoraFrameHeader()
 }
 
 TypeId
-LoraFrameHeader::GetTypeId(void)
+LoraFrameHeader::GetTypeId()
 {
     static TypeId tid =
         TypeId("LoraFrameHeader").SetParent<Header>().AddConstructor<LoraFrameHeader>();
@@ -56,13 +56,13 @@ LoraFrameHeader::GetTypeId(void)
 }
 
 TypeId
-LoraFrameHeader::GetInstanceTypeId(void) const
+LoraFrameHeader::GetInstanceTypeId() const
 {
     return GetTypeId();
 }
 
 uint32_t
-LoraFrameHeader::GetSerializedSize(void) const
+LoraFrameHeader::GetSerializedSize() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -168,63 +168,63 @@ LoraFrameHeader::Deserialize(Buffer::Iterator start)
                 NS_LOG_DEBUG("Creating a LinkCheckReq command");
                 Ptr<LinkCheckReq> command = Create<LinkCheckReq>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x03): {
                 NS_LOG_DEBUG("Creating a LinkAdrAns command");
                 Ptr<LinkAdrAns> command = Create<LinkAdrAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x04): {
                 NS_LOG_DEBUG("Creating a DutyCycleAns command");
                 Ptr<DutyCycleAns> command = Create<DutyCycleAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x05): {
                 NS_LOG_DEBUG("Creating a RxParamSetupAns command");
                 Ptr<RxParamSetupAns> command = Create<RxParamSetupAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x06): {
                 NS_LOG_DEBUG("Creating a DevStatusAns command");
                 Ptr<DevStatusAns> command = Create<DevStatusAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x07): {
                 NS_LOG_DEBUG("Creating a NewChannelAns command");
                 Ptr<NewChannelAns> command = Create<NewChannelAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x08): {
                 NS_LOG_DEBUG("Creating a RxTimingSetupAns command");
                 Ptr<RxTimingSetupAns> command = Create<RxTimingSetupAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x09): {
                 NS_LOG_DEBUG("Creating a TxParamSetupAns command");
                 Ptr<TxParamSetupAns> command = Create<TxParamSetupAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x0A): {
                 NS_LOG_DEBUG("Creating a DlChannelAns command");
                 Ptr<DlChannelAns> command = Create<DlChannelAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             default: {
@@ -242,56 +242,56 @@ LoraFrameHeader::Deserialize(Buffer::Iterator start)
                 NS_LOG_DEBUG("Creating a LinkCheckAns command");
                 Ptr<LinkCheckAns> command = Create<LinkCheckAns>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x03): {
                 NS_LOG_DEBUG("Creating a LinkAdrReq command");
                 Ptr<LinkAdrReq> command = Create<LinkAdrReq>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x04): {
                 NS_LOG_DEBUG("Creating a DutyCycleReq command");
                 Ptr<DutyCycleReq> command = Create<DutyCycleReq>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x05): {
                 NS_LOG_DEBUG("Creating a RxParamSetupReq command");
                 Ptr<RxParamSetupReq> command = Create<RxParamSetupReq>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x06): {
                 NS_LOG_DEBUG("Creating a DevStatusReq command");
                 Ptr<DevStatusReq> command = Create<DevStatusReq>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x07): {
                 NS_LOG_DEBUG("Creating a NewChannelReq command");
                 Ptr<NewChannelReq> command = Create<NewChannelReq>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x08): {
                 NS_LOG_DEBUG("Creating a RxTimingSetupReq command");
                 Ptr<RxTimingSetupReq> command = Create<RxTimingSetupReq>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             case (0x09): {
                 NS_LOG_DEBUG("Creating a TxParamSetupReq command");
                 Ptr<TxParamSetupReq> command = Create<TxParamSetupReq>();
                 byteNumber += command->Deserialize(start);
-                m_macCommands.push_back(command);
+                m_macCommands.emplace_back(command);
                 break;
             }
             default: {
@@ -328,7 +328,7 @@ LoraFrameHeader::Print(std::ostream& os) const
 }
 
 void
-LoraFrameHeader::SetAsUplink(void)
+LoraFrameHeader::SetAsUplink()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -336,7 +336,7 @@ LoraFrameHeader::SetAsUplink(void)
 }
 
 void
-LoraFrameHeader::SetAsDownlink(void)
+LoraFrameHeader::SetAsDownlink()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -350,7 +350,7 @@ LoraFrameHeader::SetFPort(uint8_t fPort)
 }
 
 uint8_t
-LoraFrameHeader::GetFPort(void) const
+LoraFrameHeader::GetFPort() const
 {
     return m_fPort;
 }
@@ -362,7 +362,7 @@ LoraFrameHeader::SetAddress(LoraDeviceAddress address)
 }
 
 LoraDeviceAddress
-LoraFrameHeader::GetAddress(void) const
+LoraFrameHeader::GetAddress() const
 {
     return m_address;
 }
@@ -375,7 +375,7 @@ LoraFrameHeader::SetAdr(bool adr)
 }
 
 bool
-LoraFrameHeader::GetAdr(void) const
+LoraFrameHeader::GetAdr() const
 {
     return m_adr;
 }
@@ -387,7 +387,7 @@ LoraFrameHeader::SetAdrAckReq(bool adrAckReq)
 }
 
 bool
-LoraFrameHeader::GetAdrAckReq(void) const
+LoraFrameHeader::GetAdrAckReq() const
 {
     return m_adrAckReq;
 }
@@ -400,7 +400,7 @@ LoraFrameHeader::SetAck(bool ack)
 }
 
 bool
-LoraFrameHeader::GetAck(void) const
+LoraFrameHeader::GetAck() const
 {
     return m_ack;
 }
@@ -412,13 +412,13 @@ LoraFrameHeader::SetFPending(bool fPending)
 }
 
 bool
-LoraFrameHeader::GetFPending(void) const
+LoraFrameHeader::GetFPending() const
 {
     return m_fPending;
 }
 
 uint8_t
-LoraFrameHeader::GetFOptsLen(void) const
+LoraFrameHeader::GetFOptsLen() const
 {
     // Sum the serialized length of all commands in the list
     uint8_t fOptsLen = 0;
@@ -437,18 +437,18 @@ LoraFrameHeader::SetFCnt(uint16_t fCnt)
 }
 
 uint16_t
-LoraFrameHeader::GetFCnt(void) const
+LoraFrameHeader::GetFCnt() const
 {
     return m_fCnt;
 }
 
 void
-LoraFrameHeader::AddLinkCheckReq(void)
+LoraFrameHeader::AddLinkCheckReq()
 {
     NS_LOG_FUNCTION_NOARGS();
 
     Ptr<LinkCheckReq> command = Create<LinkCheckReq>();
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     NS_LOG_DEBUG("Command SerializedSize: " << unsigned(command->GetSerializedSize()));
     m_fOptsLen += command->GetSerializedSize();
@@ -460,7 +460,7 @@ LoraFrameHeader::AddLinkCheckAns(uint8_t margin, uint8_t gwCnt)
     NS_LOG_FUNCTION(this << unsigned(margin) << unsigned(gwCnt));
 
     Ptr<LinkCheckAns> command = Create<LinkCheckAns>(margin, gwCnt);
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
@@ -487,7 +487,7 @@ LoraFrameHeader::AddLinkAdrReq(uint8_t dataRate,
                                                    << " and txPower = " << unsigned(txPower));
 
     Ptr<LinkAdrReq> command = Create<LinkAdrReq>(dataRate, txPower, channelMask, 0, repetitions);
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
@@ -498,7 +498,7 @@ LoraFrameHeader::AddLinkAdrAns(bool powerAck, bool dataRateAck, bool channelMask
     NS_LOG_FUNCTION(this << powerAck << dataRateAck << channelMaskAck);
 
     Ptr<LinkAdrAns> command = Create<LinkAdrAns>(powerAck, dataRateAck, channelMaskAck);
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
@@ -510,19 +510,19 @@ LoraFrameHeader::AddDutyCycleReq(uint8_t dutyCycle)
 
     Ptr<DutyCycleReq> command = Create<DutyCycleReq>(dutyCycle);
 
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
 
 void
-LoraFrameHeader::AddDutyCycleAns(void)
+LoraFrameHeader::AddDutyCycleAns()
 {
     NS_LOG_FUNCTION(this);
 
     Ptr<DutyCycleAns> command = Create<DutyCycleAns>();
 
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
@@ -537,31 +537,31 @@ LoraFrameHeader::AddRxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, do
 
     Ptr<RxParamSetupReq> command = Create<RxParamSetupReq>(rx1DrOffset, rx2DataRate, frequency);
 
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
 
 void
-LoraFrameHeader::AddRxParamSetupAns(void)
+LoraFrameHeader::AddRxParamSetupAns()
 {
     NS_LOG_FUNCTION(this);
 
     Ptr<RxParamSetupAns> command = Create<RxParamSetupAns>();
 
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
 
 void
-LoraFrameHeader::AddDevStatusReq(void)
+LoraFrameHeader::AddDevStatusReq()
 {
     NS_LOG_FUNCTION(this);
 
     Ptr<DevStatusReq> command = Create<DevStatusReq>();
 
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
@@ -577,13 +577,13 @@ LoraFrameHeader::AddNewChannelReq(uint8_t chIndex,
     Ptr<NewChannelReq> command =
         Create<NewChannelReq>(chIndex, frequency, minDataRate, maxDataRate);
 
-    m_macCommands.push_back(command);
+    m_macCommands.emplace_back(command);
 
     m_fOptsLen += command->GetSerializedSize();
 }
 
 std::list<Ptr<MacCommand>>
-LoraFrameHeader::GetCommands(void)
+LoraFrameHeader::GetCommands()
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/lora-frame-header.h
+++ b/model/lora-frame-header.h
@@ -46,18 +46,18 @@ class LoraFrameHeader : public Header
 {
   public:
     LoraFrameHeader();
-    ~LoraFrameHeader();
+    ~LoraFrameHeader() override;
 
     // Methods inherited from Header
-    static TypeId GetTypeId(void);
-    virtual TypeId GetInstanceTypeId(void) const;
+    static TypeId GetTypeId();
+    TypeId GetInstanceTypeId() const override;
 
     /**
      * Return the size required for serialization of this header
      *
      * \return The serialized size in bytes
      */
-    virtual uint32_t GetSerializedSize(void) const;
+    uint32_t GetSerializedSize() const override;
 
     /**
      * Serialize the header.
@@ -67,7 +67,7 @@ class LoraFrameHeader : public Header
      * \param start A pointer to the buffer that will be filled with the
      * serialization.
      */
-    virtual void Serialize(Buffer::Iterator start) const;
+    void Serialize(Buffer::Iterator start) const override;
 
     /**
      * Deserialize the contents of the buffer into a LoraFrameHeader object.
@@ -75,14 +75,14 @@ class LoraFrameHeader : public Header
      * \param start A pointer to the buffer we need to deserialize.
      * \return The number of consumed bytes.
      */
-    virtual uint32_t Deserialize(Buffer::Iterator start);
+    uint32_t Deserialize(Buffer::Iterator start) override;
 
     /**
      * Print the header in a human-readable format.
      *
      * \param os The std::ostream on which to print the header.
      */
-    virtual void Print(std::ostream& os) const;
+    void Print(std::ostream& os) const override;
 
     /**
      * State that this is an uplink message.
@@ -90,7 +90,7 @@ class LoraFrameHeader : public Header
      * This method needs to be called at least once before any serialization or
      * deserialization.
      */
-    void SetAsUplink(void);
+    void SetAsUplink();
 
     /**
      * State that this is a downlink message.
@@ -98,7 +98,7 @@ class LoraFrameHeader : public Header
      * This method needs to be called at least once before any serialization or
      * deserialization.
      */
-    void SetAsDownlink(void);
+    void SetAsDownlink();
 
     /**
      * Set the FPort value.
@@ -112,7 +112,7 @@ class LoraFrameHeader : public Header
      *
      * \return The FPort value.
      */
-    uint8_t GetFPort(void) const;
+    uint8_t GetFPort() const;
 
     /**
      * Set the address.
@@ -126,7 +126,7 @@ class LoraFrameHeader : public Header
      *
      * \return The address value stored in this header.
      */
-    LoraDeviceAddress GetAddress(void) const;
+    LoraDeviceAddress GetAddress() const;
 
     /**
      * Set the Adr value.
@@ -140,7 +140,7 @@ class LoraFrameHeader : public Header
      *
      * \return The Adr value.
      */
-    bool GetAdr(void) const;
+    bool GetAdr() const;
 
     /**
      * Set the AdrAckReq value.
@@ -154,7 +154,7 @@ class LoraFrameHeader : public Header
      *
      * \return The AdrAckReq value.
      */
-    bool GetAdrAckReq(void) const;
+    bool GetAdrAckReq() const;
 
     /**
      * Set the Ack bit.
@@ -168,7 +168,7 @@ class LoraFrameHeader : public Header
      *
      * \return True if the ACK bit is set, false otherwise.
      */
-    bool GetAck(void) const;
+    bool GetAck() const;
 
     /**
      * Set the FPending value.
@@ -182,7 +182,7 @@ class LoraFrameHeader : public Header
      *
      * \return The FPending value.
      */
-    bool GetFPending(void) const;
+    bool GetFPending() const;
 
     /**
      * Get the FOptsLen value.
@@ -192,7 +192,7 @@ class LoraFrameHeader : public Header
      *
      * \return The FOptsLen value.
      */
-    uint8_t GetFOptsLen(void) const;
+    uint8_t GetFOptsLen() const;
 
     /**
      * Set the FCnt value
@@ -205,19 +205,19 @@ class LoraFrameHeader : public Header
      *
      * \return The FCnt value.
      */
-    uint16_t GetFCnt(void) const;
+    uint16_t GetFCnt() const;
 
     /**
      * Return a pointer to a MacCommand, or 0 if the MacCommand does not exist
      * in this header.
      */
     template <typename T>
-    inline Ptr<T> GetMacCommand(void);
+    inline Ptr<T> GetMacCommand();
 
     /**
      * Add a LinkCheckReq command.
      */
-    void AddLinkCheckReq(void);
+    void AddLinkCheckReq();
 
     /**
      * Add a LinkCheckAns command.
@@ -265,7 +265,7 @@ class LoraFrameHeader : public Header
     /**
      * Add a DutyCycleAns command.
      */
-    void AddDutyCycleAns(void);
+    void AddDutyCycleAns();
 
     /**
      * Add a RxParamSetupReq command.
@@ -297,7 +297,7 @@ class LoraFrameHeader : public Header
     /**
      * Return a list of pointers to all the MAC commands saved in this header.
      */
-    std::list<Ptr<MacCommand>> GetCommands(void);
+    std::list<Ptr<MacCommand>> GetCommands();
 
     /**
      * Add a predefined command to the list.
@@ -343,7 +343,7 @@ LoraFrameHeader::GetMacCommand()
     }
 
     // If no command was found, return 0
-    return 0;
+    return nullptr;
 }
 } // namespace lorawan
 

--- a/model/lora-interference-helper.cc
+++ b/model/lora-interference-helper.cc
@@ -59,43 +59,43 @@ LoraInterferenceHelper::Event::~Event()
 
 // Getters
 Time
-LoraInterferenceHelper::Event::GetStartTime(void) const
+LoraInterferenceHelper::Event::GetStartTime() const
 {
     return m_startTime;
 }
 
 Time
-LoraInterferenceHelper::Event::GetEndTime(void) const
+LoraInterferenceHelper::Event::GetEndTime() const
 {
     return m_endTime;
 }
 
 Time
-LoraInterferenceHelper::Event::GetDuration(void) const
+LoraInterferenceHelper::Event::GetDuration() const
 {
     return m_endTime - m_startTime;
 }
 
 double
-LoraInterferenceHelper::Event::GetRxPowerdBm(void) const
+LoraInterferenceHelper::Event::GetRxPowerdBm() const
 {
     return m_rxPowerdBm;
 }
 
 uint8_t
-LoraInterferenceHelper::Event::GetSpreadingFactor(void) const
+LoraInterferenceHelper::Event::GetSpreadingFactor() const
 {
     return m_sf;
 }
 
 Ptr<Packet>
-LoraInterferenceHelper::Event::GetPacket(void) const
+LoraInterferenceHelper::Event::GetPacket() const
 {
     return m_packet;
 }
 
 double
-LoraInterferenceHelper::Event::GetFrequency(void) const
+LoraInterferenceHelper::Event::GetFrequency() const
 {
     return m_frequencyMHz;
 }
@@ -168,7 +168,7 @@ LoraInterferenceHelper::SetCollisionMatrix(
 }
 
 TypeId
-LoraInterferenceHelper::GetTypeId(void)
+LoraInterferenceHelper::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LoraInterferenceHelper").SetParent<Object>().SetGroupName("lorawan");
@@ -222,7 +222,7 @@ LoraInterferenceHelper::Add(Time duration,
 }
 
 void
-LoraInterferenceHelper::CleanOldEvents(void)
+LoraInterferenceHelper::CleanOldEvents()
 {
     NS_LOG_FUNCTION(this);
 
@@ -280,7 +280,6 @@ LoraInterferenceHelper::IsDestroyedByInterference(Ptr<LoraInterferenceHelper::Ev
     Time now = Simulator::Now();
     Time duration = event->GetDuration();
     Time packetStartTime = now - duration;
-    Time packetEndTime = now;
 
     // Get the list of interfering events
     std::list<Ptr<LoraInterferenceHelper::Event>>::iterator it;
@@ -335,7 +334,7 @@ LoraInterferenceHelper::IsDestroyedByInterference(Ptr<LoraInterferenceHelper::Ev
     }
 
     // For each SF, check if there was destructive interference
-    for (uint8_t currentSf = uint8_t(7); currentSf <= uint8_t(12); currentSf++)
+    for (auto currentSf = uint8_t(7); currentSf <= uint8_t(12); currentSf++)
     {
         NS_LOG_DEBUG("Cumulative Interference Energy: "
                      << cumulativeInterferenceEnergy.at(unsigned(currentSf) - 7));
@@ -374,7 +373,7 @@ LoraInterferenceHelper::IsDestroyedByInterference(Ptr<LoraInterferenceHelper::Ev
 }
 
 void
-LoraInterferenceHelper::ClearAllEvents(void)
+LoraInterferenceHelper::ClearAllEvents()
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/lora-interference-helper.h
+++ b/model/lora-interference-helper.h
@@ -65,37 +65,37 @@ class LoraInterferenceHelper
         /**
          * Get the duration of the event.
          */
-        Time GetDuration(void) const;
+        Time GetDuration() const;
 
         /**
          * Get the starting time of the event.
          */
-        Time GetStartTime(void) const;
+        Time GetStartTime() const;
 
         /**
          * Get the ending time of the event.
          */
-        Time GetEndTime(void) const;
+        Time GetEndTime() const;
 
         /**
          * Get the power of the event.
          */
-        double GetRxPowerdBm(void) const;
+        double GetRxPowerdBm() const;
 
         /**
          * Get the spreading factor used by this signal.
          */
-        uint8_t GetSpreadingFactor(void) const;
+        uint8_t GetSpreadingFactor() const;
 
         /**
          * Get the packet this event was generated for.
          */
-        Ptr<Packet> GetPacket(void) const;
+        Ptr<Packet> GetPacket() const;
 
         /**
          * Get the frequency this event was on.
          */
-        double GetFrequency(void) const;
+        double GetFrequency() const;
 
         /**
          * Print the current event in a human readable form.
@@ -140,7 +140,7 @@ class LoraInterferenceHelper
         ALOHA,
     };
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     LoraInterferenceHelper();
     virtual ~LoraInterferenceHelper();
@@ -198,12 +198,12 @@ class LoraInterferenceHelper
     /**
      * Delete all events in the LoraInterferenceHelper.
      */
-    void ClearAllEvents(void);
+    void ClearAllEvents();
 
     /**
      * Delete old events in this LoraInterferenceHelper.
      */
-    void CleanOldEvents(void);
+    void CleanOldEvents();
 
     static CollisionMatrix collisionMatrix;
 

--- a/model/lora-net-device.cc
+++ b/model/lora-net-device.cc
@@ -34,7 +34,7 @@ NS_LOG_COMPONENT_DEFINE("LoraNetDevice");
 NS_OBJECT_ENSURE_REGISTERED(LoraNetDevice);
 
 TypeId
-LoraNetDevice::GetTypeId(void)
+LoraNetDevice::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LoraNetDevice")
@@ -60,10 +60,10 @@ LoraNetDevice::GetTypeId(void)
 }
 
 LoraNetDevice::LoraNetDevice()
-    : m_node(0),
-      m_phy(0),
-      m_mac(0),
-      m_configComplete(0)
+    : m_node(nullptr),
+      m_phy(nullptr),
+      m_mac(nullptr),
+      m_configComplete(false)
 {
     NS_LOG_FUNCTION_NOARGS();
 }
@@ -80,7 +80,7 @@ LoraNetDevice::SetMac(Ptr<LorawanMac> mac)
 }
 
 Ptr<LorawanMac>
-LoraNetDevice::GetMac(void) const
+LoraNetDevice::GetMac() const
 {
     return m_mac;
 }
@@ -92,13 +92,13 @@ LoraNetDevice::SetPhy(Ptr<LoraPhy> phy)
 }
 
 Ptr<LoraPhy>
-LoraNetDevice::GetPhy(void) const
+LoraNetDevice::GetPhy() const
 {
     return m_phy;
 }
 
 void
-LoraNetDevice::CompleteConfig(void)
+LoraNetDevice::CompleteConfig()
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -137,14 +137,14 @@ LoraNetDevice::Receive(Ptr<Packet> packet)
  ******************************************/
 
 Ptr<Channel>
-LoraNetDevice::GetChannel(void) const
+LoraNetDevice::GetChannel() const
 {
     NS_LOG_FUNCTION(this);
     return m_phy->GetChannel();
 }
 
 Ptr<LoraChannel>
-LoraNetDevice::DoGetChannel(void) const
+LoraNetDevice::DoGetChannel() const
 {
     NS_LOG_FUNCTION(this);
     return m_phy->GetChannel();
@@ -157,7 +157,7 @@ LoraNetDevice::SetIfIndex(const uint32_t index)
 }
 
 uint32_t
-LoraNetDevice::GetIfIndex(void) const
+LoraNetDevice::GetIfIndex() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -171,7 +171,7 @@ LoraNetDevice::SetAddress(Address address)
 }
 
 Address
-LoraNetDevice::GetAddress(void) const
+LoraNetDevice::GetAddress() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -187,7 +187,7 @@ LoraNetDevice::SetMtu(const uint16_t mtu)
 }
 
 uint16_t
-LoraNetDevice::GetMtu(void) const
+LoraNetDevice::GetMtu() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -195,7 +195,7 @@ LoraNetDevice::GetMtu(void) const
 }
 
 bool
-LoraNetDevice::IsLinkUp(void) const
+LoraNetDevice::IsLinkUp() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -209,7 +209,7 @@ LoraNetDevice::AddLinkChangeCallback(Callback<void> callback)
 }
 
 bool
-LoraNetDevice::IsBroadcast(void) const
+LoraNetDevice::IsBroadcast() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -217,7 +217,7 @@ LoraNetDevice::IsBroadcast(void) const
 }
 
 Address
-LoraNetDevice::GetBroadcast(void) const
+LoraNetDevice::GetBroadcast() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -225,7 +225,7 @@ LoraNetDevice::GetBroadcast(void) const
 }
 
 bool
-LoraNetDevice::IsMulticast(void) const
+LoraNetDevice::IsMulticast() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -249,7 +249,7 @@ LoraNetDevice::GetMulticast(Ipv6Address addr) const
 }
 
 bool
-LoraNetDevice::IsBridge(void) const
+LoraNetDevice::IsBridge() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -257,7 +257,7 @@ LoraNetDevice::IsBridge(void) const
 }
 
 bool
-LoraNetDevice::IsPointToPoint(void) const
+LoraNetDevice::IsPointToPoint() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -289,7 +289,7 @@ LoraNetDevice::SendFrom(Ptr<Packet> packet,
 }
 
 Ptr<Node>
-LoraNetDevice::GetNode(void) const
+LoraNetDevice::GetNode() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -306,7 +306,7 @@ LoraNetDevice::SetNode(Ptr<Node> node)
 }
 
 bool
-LoraNetDevice::NeedsArp(void) const
+LoraNetDevice::NeedsArp() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -327,7 +327,7 @@ LoraNetDevice::SetPromiscReceiveCallback(PromiscReceiveCallback cb)
 }
 
 bool
-LoraNetDevice::SupportsSendFrom(void) const
+LoraNetDevice::SupportsSendFrom() const
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/lora-net-device.h
+++ b/model/lora-net-device.h
@@ -46,11 +46,11 @@ class LorawanMac;
 class LoraNetDevice : public NetDevice
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     // Constructor and destructor
     LoraNetDevice();
-    virtual ~LoraNetDevice();
+    ~LoraNetDevice() override;
 
     /**
      * Set which LorawanMac instance is linked to this device.
@@ -71,14 +71,14 @@ class LoraNetDevice : public NetDevice
      *
      * \return the mac we are currently using.
      */
-    Ptr<LorawanMac> GetMac(void) const;
+    Ptr<LorawanMac> GetMac() const;
 
     /**
      * Get the LoraPhy instance that is linked to this NetDevice.
      *
      * \return the phy we are currently using.
      */
-    Ptr<LoraPhy> GetPhy(void) const;
+    Ptr<LoraPhy> GetPhy() const;
 
     /**
      * Send a packet through the LoRaWAN stack.
@@ -91,7 +91,7 @@ class LoraNetDevice : public NetDevice
      * This function is implemented to achieve compliance with the NetDevice
      * interface. Note that the dest and protocolNumber args are ignored.
      */
-    bool Send(Ptr<Packet> packet, const Address& dest, uint16_t protocolNumber);
+    bool Send(Ptr<Packet> packet, const Address& dest, uint16_t protocolNumber) override;
 
     /**
      * Callback the Mac layer calls whenever a packet arrives and needs to be
@@ -103,33 +103,33 @@ class LoraNetDevice : public NetDevice
 
     // From class NetDevice. Some of these have little meaning for a LoRaWAN
     // network device (since, for instance, IP is not used in the standard)
-    virtual void SetReceiveCallback(NetDevice::ReceiveCallback cb);
-    virtual Ptr<Channel> GetChannel(void) const;
-    virtual void SetNode(Ptr<Node> node);
-    virtual Ptr<Node> GetNode(void) const;
+    void SetReceiveCallback(NetDevice::ReceiveCallback cb) override;
+    Ptr<Channel> GetChannel() const override;
+    void SetNode(Ptr<Node> node) override;
+    Ptr<Node> GetNode() const override;
 
-    virtual void SetIfIndex(const uint32_t index);
-    virtual uint32_t GetIfIndex(void) const;
-    virtual void SetAddress(Address address);
-    virtual Address GetAddress(void) const;
-    virtual bool SetMtu(const uint16_t mtu);
-    virtual uint16_t GetMtu(void) const;
-    virtual bool IsLinkUp(void) const;
-    virtual void AddLinkChangeCallback(Callback<void> callback);
-    virtual bool IsBroadcast(void) const;
-    virtual Address GetBroadcast(void) const;
-    virtual bool IsMulticast(void) const;
-    virtual Address GetMulticast(Ipv4Address multicastGroup) const;
-    virtual Address GetMulticast(Ipv6Address addr) const;
-    virtual bool IsBridge(void) const;
-    virtual bool IsPointToPoint(void) const;
-    virtual bool SendFrom(Ptr<Packet> packet,
-                          const Address& source,
-                          const Address& dest,
-                          uint16_t protocolNumber);
-    virtual bool NeedsArp(void) const;
-    virtual void SetPromiscReceiveCallback(PromiscReceiveCallback cb);
-    virtual bool SupportsSendFrom(void) const;
+    void SetIfIndex(const uint32_t index) override;
+    uint32_t GetIfIndex() const override;
+    void SetAddress(Address address) override;
+    Address GetAddress() const override;
+    bool SetMtu(const uint16_t mtu) override;
+    uint16_t GetMtu() const override;
+    bool IsLinkUp() const override;
+    void AddLinkChangeCallback(Callback<void> callback) override;
+    bool IsBroadcast() const override;
+    Address GetBroadcast() const override;
+    bool IsMulticast() const override;
+    Address GetMulticast(Ipv4Address multicastGroup) const override;
+    Address GetMulticast(Ipv6Address addr) const override;
+    bool IsBridge() const override;
+    bool IsPointToPoint() const override;
+    bool SendFrom(Ptr<Packet> packet,
+                  const Address& source,
+                  const Address& dest,
+                  uint16_t protocolNumber) override;
+    bool NeedsArp() const override;
+    void SetPromiscReceiveCallback(PromiscReceiveCallback cb) override;
+    bool SupportsSendFrom() const override;
 
   protected:
     /**
@@ -146,13 +146,13 @@ class LoraNetDevice : public NetDevice
     /**
      * Return the LoraChannel this device is connected to.
      */
-    Ptr<LoraChannel> DoGetChannel(void) const;
+    Ptr<LoraChannel> DoGetChannel() const;
 
     /**
      * Complete the configuration of this LoRa device by connecting all lower
      * components (PHY, MAC, Channel) together.
      */
-    void CompleteConfig(void);
+    void CompleteConfig();
 
     // Member variables
     Ptr<Node> m_node;      //!< The Node this NetDevice is connected to.

--- a/model/lora-phy.cc
+++ b/model/lora-phy.cc
@@ -34,7 +34,7 @@ NS_LOG_COMPONENT_DEFINE("LoraPhy");
 NS_OBJECT_ENSURE_REGISTERED(LoraPhy);
 
 TypeId
-LoraPhy::GetTypeId(void)
+LoraPhy::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LoraPhy")
@@ -85,7 +85,7 @@ LoraPhy::~LoraPhy()
 }
 
 Ptr<NetDevice>
-LoraPhy::GetDevice(void) const
+LoraPhy::GetDevice() const
 {
     return m_device;
 }
@@ -99,7 +99,7 @@ LoraPhy::SetDevice(Ptr<NetDevice> device)
 }
 
 Ptr<LoraChannel>
-LoraPhy::GetChannel(void) const
+LoraPhy::GetChannel() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -107,7 +107,7 @@ LoraPhy::GetChannel(void) const
 }
 
 Ptr<MobilityModel>
-LoraPhy::GetMobility(void)
+LoraPhy::GetMobility()
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/lora-phy.h
+++ b/model/lora-phy.h
@@ -45,13 +45,13 @@ class LoraChannel;
  */
 struct LoraTxParameters
 {
-    uint8_t sf = 7;                          //!< Spreading Factor
-    bool headerDisabled = 0;                 //!< Whether to use implicit header mode
-    uint8_t codingRate = 1;                  //!< Code rate (obtained as 4/(codingRate+4))
-    double bandwidthHz = 125000;             //!< Bandwidth in Hz
-    uint32_t nPreamble = 8;                  //!< Number of preamble symbols
-    bool crcEnabled = 1;                     //!< Whether Cyclic Redundancy Check is enabled
-    bool lowDataRateOptimizationEnabled = 0; //!< Whether Low Data Rate Optimization is enabled
+    uint8_t sf = 7;                              //!< Spreading Factor
+    bool headerDisabled = false;                 //!< Whether to use implicit header mode
+    uint8_t codingRate = 1;                      //!< Code rate (obtained as 4/(codingRate+4))
+    double bandwidthHz = 125000;                 //!< Bandwidth in Hz
+    uint32_t nPreamble = 8;                      //!< Number of preamble symbols
+    bool crcEnabled = true;                      //!< Whether Cyclic Redundancy Check is enabled
+    bool lowDataRateOptimizationEnabled = false; //!< Whether Low Data Rate Optimization is enabled
 };
 
 /**
@@ -74,13 +74,13 @@ class LoraPhy : public Object
 {
   public:
     // TypeId
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     /**
      * Constructor and destructor
      */
     LoraPhy();
-    virtual ~LoraPhy();
+    ~LoraPhy() override;
 
     /**
      * Type definition for a callback for when a packet is correctly received.
@@ -157,7 +157,7 @@ class LoraPhy : public Object
      * \returns true if the device is currently transmitting a packet, false
      * otherwise.
      */
-    virtual bool IsTransmitting(void) = 0;
+    virtual bool IsTransmitting() = 0;
 
     /**
      * Whether this device is listening on the specified frequency or not.
@@ -221,14 +221,14 @@ class LoraPhy : public Object
      *
      * \return The LoraChannel instance this PHY transmits on.
      */
-    Ptr<LoraChannel> GetChannel(void) const;
+    Ptr<LoraChannel> GetChannel() const;
 
     /**
      * Get the NetDevice associated to this PHY.
      *
      * \return The NetDevice associated to this PHY.
      */
-    Ptr<NetDevice> GetDevice(void) const;
+    Ptr<NetDevice> GetDevice() const;
 
     /**
      * Set the NetDevice that owns this PHY.

--- a/model/lora-radio-energy-model.cc
+++ b/model/lora-radio-energy-model.cc
@@ -30,7 +30,7 @@ NS_LOG_COMPONENT_DEFINE("LoraRadioEnergyModel");
 NS_OBJECT_ENSURE_REGISTERED(LoraRadioEnergyModel);
 
 TypeId
-LoraRadioEnergyModel::GetTypeId(void)
+LoraRadioEnergyModel::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LoraRadioEnergyModel")
@@ -82,7 +82,7 @@ LoraRadioEnergyModel::LoraRadioEnergyModel()
     m_nPendingChangeState = 0;
     m_isSupersededChangeState = false;
     m_energyDepletionCallback.Nullify();
-    m_source = NULL;
+    m_source = nullptr;
     // set callback for EndDeviceLoraPhy listener
     m_listener = new LoraRadioEnergyModelPhyListener;
     m_listener->SetChangeStateCallback(MakeCallback(&DeviceEnergyModel::ChangeState, this));
@@ -101,19 +101,19 @@ void
 LoraRadioEnergyModel::SetEnergySource(Ptr<EnergySource> source)
 {
     NS_LOG_FUNCTION(this << source);
-    NS_ASSERT(source != NULL);
+    NS_ASSERT(source);
     m_source = source;
 }
 
 double
-LoraRadioEnergyModel::GetTotalEnergyConsumption(void) const
+LoraRadioEnergyModel::GetTotalEnergyConsumption() const
 {
     NS_LOG_FUNCTION(this);
     return m_totalEnergyConsumption;
 }
 
 double
-LoraRadioEnergyModel::GetStandbyCurrentA(void) const
+LoraRadioEnergyModel::GetStandbyCurrentA() const
 {
     NS_LOG_FUNCTION(this);
     return m_idleCurrentA;
@@ -127,7 +127,7 @@ LoraRadioEnergyModel::SetStandbyCurrentA(double idleCurrentA)
 }
 
 double
-LoraRadioEnergyModel::GetTxCurrentA(void) const
+LoraRadioEnergyModel::GetTxCurrentA() const
 {
     NS_LOG_FUNCTION(this);
     return m_txCurrentA;
@@ -141,7 +141,7 @@ LoraRadioEnergyModel::SetTxCurrentA(double txCurrentA)
 }
 
 double
-LoraRadioEnergyModel::GetRxCurrentA(void) const
+LoraRadioEnergyModel::GetRxCurrentA() const
 {
     NS_LOG_FUNCTION(this);
     return m_rxCurrentA;
@@ -155,7 +155,7 @@ LoraRadioEnergyModel::SetRxCurrentA(double rxCurrentA)
 }
 
 double
-LoraRadioEnergyModel::GetSleepCurrentA(void) const
+LoraRadioEnergyModel::GetSleepCurrentA() const
 {
     NS_LOG_FUNCTION(this);
     return m_sleepCurrentA;
@@ -169,7 +169,7 @@ LoraRadioEnergyModel::SetSleepCurrentA(double sleepCurrentA)
 }
 
 EndDeviceLoraPhy::State
-LoraRadioEnergyModel::GetCurrentState(void) const
+LoraRadioEnergyModel::GetCurrentState() const
 {
     NS_LOG_FUNCTION(this);
     return m_currentState;
@@ -275,7 +275,7 @@ LoraRadioEnergyModel::ChangeState(int newState)
 }
 
 void
-LoraRadioEnergyModel::HandleEnergyDepletion(void)
+LoraRadioEnergyModel::HandleEnergyDepletion()
 {
     NS_LOG_FUNCTION(this);
     NS_LOG_DEBUG("LoraRadioEnergyModel:Energy is depleted!");
@@ -287,14 +287,14 @@ LoraRadioEnergyModel::HandleEnergyDepletion(void)
 }
 
 void
-LoraRadioEnergyModel::HandleEnergyChanged(void)
+LoraRadioEnergyModel::HandleEnergyChanged()
 {
     NS_LOG_FUNCTION(this);
     NS_LOG_DEBUG("LoraRadioEnergyModel:Energy changed!");
 }
 
 void
-LoraRadioEnergyModel::HandleEnergyRecharged(void)
+LoraRadioEnergyModel::HandleEnergyRecharged()
 {
     NS_LOG_FUNCTION(this);
     NS_LOG_DEBUG("LoraRadioEnergyModel:Energy is recharged!");
@@ -306,7 +306,7 @@ LoraRadioEnergyModel::HandleEnergyRecharged(void)
 }
 
 LoraRadioEnergyModelPhyListener*
-LoraRadioEnergyModel::GetPhyListener(void)
+LoraRadioEnergyModel::GetPhyListener()
 {
     NS_LOG_FUNCTION(this);
     return m_listener;
@@ -317,15 +317,15 @@ LoraRadioEnergyModel::GetPhyListener(void)
  */
 
 void
-LoraRadioEnergyModel::DoDispose(void)
+LoraRadioEnergyModel::DoDispose()
 {
     NS_LOG_FUNCTION(this);
-    m_source = NULL;
+    m_source = nullptr;
     m_energyDepletionCallback.Nullify();
 }
 
 double
-LoraRadioEnergyModel::DoGetCurrentA(void) const
+LoraRadioEnergyModel::DoGetCurrentA() const
 {
     NS_LOG_FUNCTION(this);
     switch (m_currentState)
@@ -427,7 +427,7 @@ LoraRadioEnergyModelPhyListener::NotifyTxStart(double txPowerDbm)
 }
 
 void
-LoraRadioEnergyModelPhyListener::NotifySleep(void)
+LoraRadioEnergyModelPhyListener::NotifySleep()
 {
     NS_LOG_FUNCTION(this);
     if (m_changeStateCallback.IsNull())
@@ -438,7 +438,7 @@ LoraRadioEnergyModelPhyListener::NotifySleep(void)
 }
 
 void
-LoraRadioEnergyModelPhyListener::NotifyStandby(void)
+LoraRadioEnergyModelPhyListener::NotifyStandby()
 {
     NS_LOG_FUNCTION(this);
     if (m_changeStateCallback.IsNull())
@@ -453,7 +453,7 @@ LoraRadioEnergyModelPhyListener::NotifyStandby(void)
  */
 
 void
-LoraRadioEnergyModelPhyListener::SwitchToStandby(void)
+LoraRadioEnergyModelPhyListener::SwitchToStandby()
 {
     NS_LOG_FUNCTION(this);
     if (m_changeStateCallback.IsNull())

--- a/model/lora-radio-energy-model.h
+++ b/model/lora-radio-energy-model.h
@@ -39,7 +39,7 @@ class LoraRadioEnergyModelPhyListener : public EndDeviceLoraPhyListener
     typedef Callback<void, double> UpdateTxCurrentCallback;
 
     LoraRadioEnergyModelPhyListener();
-    virtual ~LoraRadioEnergyModelPhyListener();
+    ~LoraRadioEnergyModelPhyListener() override;
 
     /**
      * \brief Sets the change state callback. Used by helper class.
@@ -62,7 +62,7 @@ class LoraRadioEnergyModelPhyListener : public EndDeviceLoraPhyListener
      *
      * Defined in ns3::LoraEndDevicePhyListener
      */
-    void NotifyRxStart(void);
+    void NotifyRxStart() override;
 
     /**
      * \brief Switches the LoraRadioEnergyModel to TX state and switches back to
@@ -73,23 +73,23 @@ class LoraRadioEnergyModelPhyListener : public EndDeviceLoraPhyListener
      *
      * Defined in ns3::LoraEndDevicePhyListener
      */
-    void NotifyTxStart(double txPowerDbm);
+    void NotifyTxStart(double txPowerDbm) override;
 
     /**
      * Defined in ns3::LoraEndDevicePhyListener
      */
-    void NotifySleep(void);
+    void NotifySleep() override;
 
     /**
      * Defined in ns3::LoraEndDevicePhyListener
      */
-    void NotifyStandby(void);
+    void NotifyStandby() override;
 
   private:
     /**
      * A helper function that makes scheduling m_changeStateCallback possible.
      */
-    void SwitchToStandby(void);
+    void SwitchToStandby();
 
     /**
      * Change state callback used to notify the LoraRadioEnergyModel of a state
@@ -141,9 +141,9 @@ class LoraRadioEnergyModel : public DeviceEnergyModel
      * \brief Get the type ID.
      * \return the object TypeId
      */
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
     LoraRadioEnergyModel();
-    virtual ~LoraRadioEnergyModel();
+    ~LoraRadioEnergyModel() override;
 
     /**
      * \brief Sets pointer to EnergySouce installed on node.
@@ -152,14 +152,14 @@ class LoraRadioEnergyModel : public DeviceEnergyModel
      *
      * Implements DeviceEnergyModel::SetEnergySource.
      */
-    void SetEnergySource(Ptr<EnergySource> source);
+    void SetEnergySource(Ptr<EnergySource> source) override;
 
     /**
      * \returns Total energy consumption of the wifi device.
      *
      * Implements DeviceEnergyModel::GetTotalEnergyConsumption.
      */
-    double GetTotalEnergyConsumption(void) const;
+    double GetTotalEnergyConsumption() const override;
 
     // Setter & getters for state power consumption.
     /**
@@ -167,7 +167,7 @@ class LoraRadioEnergyModel : public DeviceEnergyModel
      *
      * \returns idle current of the lora device.
      */
-    double GetStandbyCurrentA(void) const;
+    double GetStandbyCurrentA() const;
     /**
      * \brief Sets idle current.
      *
@@ -179,7 +179,7 @@ class LoraRadioEnergyModel : public DeviceEnergyModel
      *
      * \returns transmit current of the lora device.
      */
-    double GetTxCurrentA(void) const;
+    double GetTxCurrentA() const;
     /**
      * \brief Sets transmit current.
      *
@@ -191,7 +191,7 @@ class LoraRadioEnergyModel : public DeviceEnergyModel
      *
      * \returns receive current of the lora device.
      */
-    double GetRxCurrentA(void) const;
+    double GetRxCurrentA() const;
     /**
      * \brief Sets receive current.
      *
@@ -203,7 +203,7 @@ class LoraRadioEnergyModel : public DeviceEnergyModel
      *
      * \returns sleep current of the lora device.
      */
-    double GetSleepCurrentA(void) const;
+    double GetSleepCurrentA() const;
     /**
      * \brief Sets sleep current.
      *
@@ -214,7 +214,7 @@ class LoraRadioEnergyModel : public DeviceEnergyModel
     /**
      * \returns Current state.
      */
-    EndDeviceLoraPhy::State GetCurrentState(void) const;
+    EndDeviceLoraPhy::State GetCurrentState() const;
 
     /**
      * \param callback Callback function.
@@ -252,43 +252,43 @@ class LoraRadioEnergyModel : public DeviceEnergyModel
      *
      * Implements DeviceEnergyModel::ChangeState.
      */
-    void ChangeState(int newState);
+    void ChangeState(int newState) override;
 
     /**
      * \brief Handles energy depletion.
      *
      * Implements DeviceEnergyModel::HandleEnergyDepletion
      */
-    void HandleEnergyDepletion(void);
+    void HandleEnergyDepletion() override;
 
     /**
      * \brief Handles energy recharged.
      *
      * Implements DeviceEnergyModel::HandleEnergyChanged
      */
-    void HandleEnergyChanged(void);
+    void HandleEnergyChanged() override;
 
     /**
      * \brief Handles energy recharged.
      *
      * Implements DeviceEnergyModel::HandleEnergyRecharged
      */
-    void HandleEnergyRecharged(void);
+    void HandleEnergyRecharged() override;
 
     /**
      * \returns Pointer to the PHY listener.
      */
-    LoraRadioEnergyModelPhyListener* GetPhyListener(void);
+    LoraRadioEnergyModelPhyListener* GetPhyListener();
 
   private:
-    void DoDispose(void);
+    void DoDispose() override;
 
     /**
      * \returns Current draw of device, at current state.
      *
      * Implements DeviceEnergyModel::GetCurrentA.
      */
-    double DoGetCurrentA(void) const;
+    double DoGetCurrentA() const override;
 
     /**
      * \param state New state the radio device is currently in.

--- a/model/lora-tag.cc
+++ b/model/lora-tag.cc
@@ -30,7 +30,7 @@ namespace lorawan
 NS_OBJECT_ENSURE_REGISTERED(LoraTag);
 
 TypeId
-LoraTag::GetTypeId(void)
+LoraTag::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LoraTag").SetParent<Tag>().SetGroupName("lorawan").AddConstructor<LoraTag>();
@@ -38,7 +38,7 @@ LoraTag::GetTypeId(void)
 }
 
 TypeId
-LoraTag::GetInstanceTypeId(void) const
+LoraTag::GetInstanceTypeId() const
 {
     return GetTypeId();
 }
@@ -57,7 +57,7 @@ LoraTag::~LoraTag()
 }
 
 uint32_t
-LoraTag::GetSerializedSize(void) const
+LoraTag::GetSerializedSize() const
 {
     // Each datum about a SF is 1 byte + receivePower (the size of a double) +
     // frequency (the size of a double)
@@ -133,13 +133,13 @@ LoraTag::SetFrequency(double frequency)
 }
 
 double
-LoraTag::GetFrequency(void)
+LoraTag::GetFrequency() const
 {
     return m_frequency;
 }
 
 uint8_t
-LoraTag::GetDataRate(void)
+LoraTag::GetDataRate() const
 {
     return m_dataRate;
 }

--- a/model/lora-tag.h
+++ b/model/lora-tag.h
@@ -34,8 +34,8 @@ namespace lorawan
 class LoraTag : public Tag
 {
   public:
-    static TypeId GetTypeId(void);
-    virtual TypeId GetInstanceTypeId(void) const;
+    static TypeId GetTypeId();
+    TypeId GetInstanceTypeId() const override;
 
     /**
      * Create a LoraTag with a given spreading factor and collision.
@@ -45,12 +45,12 @@ class LoraTag : public Tag
      */
     LoraTag(uint8_t sf = 0, uint8_t destroyedBy = 0);
 
-    virtual ~LoraTag();
+    ~LoraTag() override;
 
-    virtual void Serialize(TagBuffer i) const;
-    virtual void Deserialize(TagBuffer i);
-    virtual uint32_t GetSerializedSize() const;
-    virtual void Print(std::ostream& os) const;
+    void Serialize(TagBuffer i) const override;
+    void Deserialize(TagBuffer i) override;
+    uint32_t GetSerializedSize() const override;
+    void Print(std::ostream& os) const override;
 
     /**
      * Read which Spreading Factor this packet was transmitted with.
@@ -108,14 +108,14 @@ class LoraTag : public Tag
     /**
      * Get the frequency of the packet.
      */
-    double GetFrequency(void);
+    double GetFrequency() const;
 
     /**
      * Get the data rate for this packet.
      *
      * \return The data rate that needs to be employed for this packet.
      */
-    uint8_t GetDataRate(void);
+    uint8_t GetDataRate() const;
 
     /**
      * Set the data rate for this packet.

--- a/model/lora-tx-current-model.cc
+++ b/model/lora-tx-current-model.cc
@@ -29,7 +29,7 @@ NS_LOG_COMPONENT_DEFINE("LoraTxCurrentModel");
 NS_OBJECT_ENSURE_REGISTERED(LoraTxCurrentModel);
 
 TypeId
-LoraTxCurrentModel::GetTypeId(void)
+LoraTxCurrentModel::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::LoraTxCurrentModel").SetParent<Object>().SetGroupName("Lora");
     return tid;
@@ -47,7 +47,7 @@ LoraTxCurrentModel::~LoraTxCurrentModel()
 NS_OBJECT_ENSURE_REGISTERED(LinearLoraTxCurrentModel);
 
 TypeId
-LinearLoraTxCurrentModel::GetTypeId(void)
+LinearLoraTxCurrentModel::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LinearLoraTxCurrentModel")
@@ -107,19 +107,19 @@ LinearLoraTxCurrentModel::SetStandbyCurrent(double idleCurrent)
 }
 
 double
-LinearLoraTxCurrentModel::GetEta(void) const
+LinearLoraTxCurrentModel::GetEta() const
 {
     return m_eta;
 }
 
 double
-LinearLoraTxCurrentModel::GetVoltage(void) const
+LinearLoraTxCurrentModel::GetVoltage() const
 {
     return m_voltage;
 }
 
 double
-LinearLoraTxCurrentModel::GetStandbyCurrent(void) const
+LinearLoraTxCurrentModel::GetStandbyCurrent() const
 {
     return m_idleCurrent;
 }
@@ -134,7 +134,7 @@ LinearLoraTxCurrentModel::CalcTxCurrent(double txPowerDbm) const
 NS_OBJECT_ENSURE_REGISTERED(ConstantLoraTxCurrentModel);
 
 TypeId
-ConstantLoraTxCurrentModel::GetTypeId(void)
+ConstantLoraTxCurrentModel::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::ConstantLoraTxCurrentModel")
@@ -168,7 +168,7 @@ ConstantLoraTxCurrentModel::SetTxCurrent(double txCurrent)
 }
 
 double
-ConstantLoraTxCurrentModel::GetTxCurrent(void) const
+ConstantLoraTxCurrentModel::GetTxCurrent() const
 {
     return m_txCurrent;
 }

--- a/model/lora-tx-current-model.h
+++ b/model/lora-tx-current-model.h
@@ -32,10 +32,10 @@ namespace lorawan
 class LoraTxCurrentModel : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     LoraTxCurrentModel();
-    virtual ~LoraTxCurrentModel();
+    ~LoraTxCurrentModel() override;
 
     /**
      * Get the current for transmission at this power.
@@ -53,10 +53,10 @@ class LoraTxCurrentModel : public Object
 class LinearLoraTxCurrentModel : public LoraTxCurrentModel
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     LinearLoraTxCurrentModel();
-    virtual ~LinearLoraTxCurrentModel();
+    ~LinearLoraTxCurrentModel() override;
 
     /**
      * \param eta (dimension-less)
@@ -82,19 +82,19 @@ class LinearLoraTxCurrentModel : public LoraTxCurrentModel
     /**
      * \return the power amplifier efficiency.
      */
-    double GetEta(void) const;
+    double GetEta() const;
 
     /**
      * \return the supply voltage.
      */
-    double GetVoltage(void) const;
+    double GetVoltage() const;
 
     /**
      * \return the current in the STANDBY state.
      */
-    double GetStandbyCurrent(void) const;
+    double GetStandbyCurrent() const;
 
-    double CalcTxCurrent(double txPowerDbm) const;
+    double CalcTxCurrent(double txPowerDbm) const override;
 
   private:
     double m_eta;         //!< ETA
@@ -109,10 +109,10 @@ class ConstantLoraTxCurrentModel : public LoraTxCurrentModel
      * \brief Get the type ID.
      * \return the object TypeId
      */
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     ConstantLoraTxCurrentModel();
-    virtual ~ConstantLoraTxCurrentModel();
+    ~ConstantLoraTxCurrentModel() override;
 
     /**
      * \param txCurrent (Ampere)
@@ -124,9 +124,9 @@ class ConstantLoraTxCurrentModel : public LoraTxCurrentModel
     /**
      * \return the current in the TX state.
      */
-    double GetTxCurrent(void) const;
+    double GetTxCurrent() const;
 
-    double CalcTxCurrent(double txPowerDbm) const;
+    double CalcTxCurrent(double txPowerDbm) const override;
 
   private:
     double m_txCurrent;

--- a/model/lorawan-mac-header.cc
+++ b/model/lorawan-mac-header.cc
@@ -40,7 +40,7 @@ LorawanMacHeader::~LorawanMacHeader()
 }
 
 TypeId
-LorawanMacHeader::GetTypeId(void)
+LorawanMacHeader::GetTypeId()
 {
     static TypeId tid =
         TypeId("LorawanMacHeader").SetParent<Header>().AddConstructor<LorawanMacHeader>();
@@ -48,13 +48,13 @@ LorawanMacHeader::GetTypeId(void)
 }
 
 TypeId
-LorawanMacHeader::GetInstanceTypeId(void) const
+LorawanMacHeader::GetInstanceTypeId() const
 {
     return GetTypeId();
 }
 
 uint32_t
-LorawanMacHeader::GetSerializedSize(void) const
+LorawanMacHeader::GetSerializedSize() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -118,7 +118,7 @@ LorawanMacHeader::SetMType(enum MType mtype)
 }
 
 uint8_t
-LorawanMacHeader::GetMType(void) const
+LorawanMacHeader::GetMType() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -136,7 +136,7 @@ LorawanMacHeader::SetMajor(uint8_t major)
 }
 
 uint8_t
-LorawanMacHeader::GetMajor(void) const
+LorawanMacHeader::GetMajor() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -144,7 +144,7 @@ LorawanMacHeader::GetMajor(void) const
 }
 
 bool
-LorawanMacHeader::IsUplink(void) const
+LorawanMacHeader::IsUplink() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -153,7 +153,7 @@ LorawanMacHeader::IsUplink(void) const
 }
 
 bool
-LorawanMacHeader::IsConfirmed(void) const
+LorawanMacHeader::IsConfirmed() const
 {
     NS_LOG_FUNCTION_NOARGS();
 

--- a/model/lorawan-mac-header.h
+++ b/model/lorawan-mac-header.h
@@ -50,14 +50,14 @@ class LorawanMacHeader : public Header
         PROPRIETARY = 7
     };
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     LorawanMacHeader();
-    ~LorawanMacHeader();
+    ~LorawanMacHeader() override;
 
     // Pure virtual methods from Header that need to be implemented by this class
-    virtual TypeId GetInstanceTypeId(void) const;
-    virtual uint32_t GetSerializedSize(void) const;
+    TypeId GetInstanceTypeId() const override;
+    uint32_t GetSerializedSize() const override;
 
     /**
      * Serialize the header.
@@ -67,7 +67,7 @@ class LorawanMacHeader : public Header
      * \param start A pointer to the buffer that will be filled with the
      * serialization.
      */
-    virtual void Serialize(Buffer::Iterator start) const;
+    void Serialize(Buffer::Iterator start) const override;
 
     /**
      * Deserialize the header.
@@ -75,14 +75,14 @@ class LorawanMacHeader : public Header
      * \param start A pointer to the buffer we need to deserialize.
      * \return The number of consumed bytes.
      */
-    virtual uint32_t Deserialize(Buffer::Iterator start);
+    uint32_t Deserialize(Buffer::Iterator start) override;
 
     /**
      * Print the header in a human readable format.
      *
      * \param os The std::ostream on which to print the header.
      */
-    virtual void Print(std::ostream& os) const;
+    void Print(std::ostream& os) const override;
 
     /**
      * Set the message type.
@@ -96,7 +96,7 @@ class LorawanMacHeader : public Header
      *
      * \return The uint8_t corresponding to this header's message type.
      */
-    uint8_t GetMType(void) const;
+    uint8_t GetMType() const;
 
     /**
      * Set the major version of this header.
@@ -110,7 +110,7 @@ class LorawanMacHeader : public Header
      *
      * \return The uint8_t corresponding to this header's major version.
      */
-    uint8_t GetMajor(void) const;
+    uint8_t GetMajor() const;
 
     /**
      * Check whether this header is for an uplink message
@@ -118,9 +118,9 @@ class LorawanMacHeader : public Header
      * \return True if the message is meant to be sent from an ED to a GW, false
      * otherwise.
      */
-    bool IsUplink(void) const;
+    bool IsUplink() const;
 
-    bool IsConfirmed(void) const;
+    bool IsConfirmed() const;
 
   private:
     /**

--- a/model/lorawan-mac.cc
+++ b/model/lorawan-mac.cc
@@ -31,7 +31,7 @@ NS_LOG_COMPONENT_DEFINE("LorawanMac");
 NS_OBJECT_ENSURE_REGISTERED(LorawanMac);
 
 TypeId
-LorawanMac::GetTypeId(void)
+LorawanMac::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::LorawanMac")
@@ -72,13 +72,13 @@ LorawanMac::SetDevice(Ptr<NetDevice> device)
 }
 
 Ptr<NetDevice>
-LorawanMac::GetDevice(void)
+LorawanMac::GetDevice()
 {
     return m_device;
 }
 
 Ptr<LoraPhy>
-LorawanMac::GetPhy(void)
+LorawanMac::GetPhy()
 {
     return m_phy;
 }
@@ -96,7 +96,7 @@ LorawanMac::SetPhy(Ptr<LoraPhy> phy)
 }
 
 LogicalLoraChannelHelper
-LorawanMac::GetLogicalLoraChannelHelper(void)
+LorawanMac::GetLogicalLoraChannelHelper()
 {
     return m_channelHelper;
 }
@@ -179,7 +179,7 @@ LorawanMac::SetNPreambleSymbols(int nPreambleSymbols)
 }
 
 int
-LorawanMac::GetNPreambleSymbols(void)
+LorawanMac::GetNPreambleSymbols() const
 {
     return m_nPreambleSymbols;
 }

--- a/model/lorawan-mac.h
+++ b/model/lorawan-mac.h
@@ -45,10 +45,10 @@ class LoraPhy;
 class LorawanMac : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     LorawanMac();
-    virtual ~LorawanMac();
+    ~LorawanMac() override;
 
     typedef std::array<std::array<uint8_t, 6>, 8> ReplyDataRateMatrix;
 
@@ -64,7 +64,7 @@ class LorawanMac : public Object
      *
      * \return The PHY layer that this MAC is connected to.
      */
-    Ptr<LoraPhy> GetPhy(void);
+    Ptr<LoraPhy> GetPhy();
 
     /**
      * Send a packet.
@@ -107,14 +107,14 @@ class LorawanMac : public Object
      *
      * \return The NetDevice this MAC layer will refer to.
      */
-    Ptr<NetDevice> GetDevice(void);
+    Ptr<NetDevice> GetDevice();
 
     /**
      * Get the logical lora channel helper associated with this MAC.
      *
      * \return The instance of LogicalLoraChannelHelper that this MAC is using.
      */
-    LogicalLoraChannelHelper GetLogicalLoraChannelHelper(void);
+    LogicalLoraChannelHelper GetLogicalLoraChannelHelper();
 
     /**
      * Set the LogicalLoraChannelHelper this MAC instance will use.
@@ -210,7 +210,7 @@ class LorawanMac : public Object
      *
      * \return The number of preamble symbols to use (typically 8).
      */
-    int GetNPreambleSymbols(void);
+    int GetNPreambleSymbols() const;
 
   protected:
     /**

--- a/model/mac-command.cc
+++ b/model/mac-command.cc
@@ -34,7 +34,7 @@ NS_LOG_COMPONENT_DEFINE("MacCommand");
 NS_OBJECT_ENSURE_REGISTERED(MacCommand);
 
 TypeId
-MacCommand::GetTypeId(void)
+MacCommand::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::MacCommand").SetParent<Object>().SetGroupName("lorawan");
     return tid;
@@ -51,7 +51,7 @@ MacCommand::~MacCommand()
 }
 
 enum MacCommandType
-MacCommand::GetCommandType(void) const
+MacCommand::GetCommandType() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -59,7 +59,7 @@ MacCommand::GetCommandType(void) const
 }
 
 uint8_t
-MacCommand::GetSerializedSize(void) const
+MacCommand::GetSerializedSize() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -230,7 +230,7 @@ LinkCheckAns::SetMargin(uint8_t margin)
 }
 
 uint8_t
-LinkCheckAns::GetMargin(void) const
+LinkCheckAns::GetMargin() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -246,7 +246,7 @@ LinkCheckAns::SetGwCnt(uint8_t gwCnt)
 }
 
 uint8_t
-LinkCheckAns::GetGwCnt(void) const
+LinkCheckAns::GetGwCnt() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -254,7 +254,7 @@ LinkCheckAns::GetGwCnt(void) const
 }
 
 void
-LinkCheckAns::IncrementGwCnt(void)
+LinkCheckAns::IncrementGwCnt()
 {
     NS_LOG_FUNCTION(this);
 
@@ -334,7 +334,7 @@ LinkAdrReq::Print(std::ostream& os) const
 }
 
 uint8_t
-LinkAdrReq::GetDataRate(void)
+LinkAdrReq::GetDataRate()
 {
     NS_LOG_FUNCTION(this);
 
@@ -342,7 +342,7 @@ LinkAdrReq::GetDataRate(void)
 }
 
 uint8_t
-LinkAdrReq::GetTxPower(void)
+LinkAdrReq::GetTxPower()
 {
     NS_LOG_FUNCTION(this);
 
@@ -350,7 +350,7 @@ LinkAdrReq::GetTxPower(void)
 }
 
 std::list<int>
-LinkAdrReq::GetEnabledChannelsList(void)
+LinkAdrReq::GetEnabledChannelsList()
 {
     NS_LOG_FUNCTION(this);
 
@@ -368,7 +368,7 @@ LinkAdrReq::GetEnabledChannelsList(void)
 }
 
 int
-LinkAdrReq::GetRepetitions(void)
+LinkAdrReq::GetRepetitions()
 {
     NS_LOG_FUNCTION(this);
 
@@ -490,7 +490,7 @@ DutyCycleReq::Print(std::ostream& os) const
 }
 
 double
-DutyCycleReq::GetMaximumAllowedDutyCycle(void) const
+DutyCycleReq::GetMaximumAllowedDutyCycle() const
 {
     NS_LOG_FUNCTION(this);
 
@@ -590,7 +590,7 @@ RxParamSetupReq::Serialize(Buffer::Iterator& start) const
     start.WriteU8(GetCIDFromMacCommand(m_commandType));
     // Data serialization
     start.WriteU8((m_rx1DrOffset & 0b111) << 4 | (m_rx2DataRate & 0b1111));
-    uint32_t encodedFrequency = uint32_t(m_frequency / 100);
+    uint32_t encodedFrequency = m_frequency / 100;
     NS_LOG_DEBUG(unsigned(encodedFrequency));
     NS_LOG_DEBUG(std::bitset<32>(encodedFrequency));
     start.WriteU8((encodedFrequency & 0xff0000) >> 16); // Most significant byte
@@ -631,7 +631,7 @@ RxParamSetupReq::Print(std::ostream& os) const
 }
 
 uint8_t
-RxParamSetupReq::GetRx1DrOffset(void)
+RxParamSetupReq::GetRx1DrOffset()
 {
     NS_LOG_FUNCTION(this);
 
@@ -639,7 +639,7 @@ RxParamSetupReq::GetRx1DrOffset(void)
 }
 
 uint8_t
-RxParamSetupReq::GetRx2DataRate(void)
+RxParamSetupReq::GetRx2DataRate()
 {
     NS_LOG_FUNCTION(this);
 
@@ -647,7 +647,7 @@ RxParamSetupReq::GetRx2DataRate(void)
 }
 
 double
-RxParamSetupReq::GetFrequency(void)
+RxParamSetupReq::GetFrequency()
 {
     NS_LOG_FUNCTION(this);
 
@@ -814,7 +814,7 @@ DevStatusAns::Print(std::ostream& os) const
 }
 
 uint8_t
-DevStatusAns::GetBattery(void)
+DevStatusAns::GetBattery() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -822,7 +822,7 @@ DevStatusAns::GetBattery(void)
 }
 
 uint8_t
-DevStatusAns::GetMargin(void)
+DevStatusAns::GetMargin() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -865,7 +865,7 @@ NewChannelReq::Serialize(Buffer::Iterator& start) const
     start.WriteU8(GetCIDFromMacCommand(m_commandType));
 
     start.WriteU8(m_chIndex);
-    uint32_t encodedFrequency = uint32_t(m_frequency / 100);
+    uint32_t encodedFrequency = m_frequency / 100;
     start.WriteU8((encodedFrequency & 0xff0000) >> 16);
     start.WriteU8((encodedFrequency & 0xff00) >> 8);
     start.WriteU8(encodedFrequency & 0xff);
@@ -901,7 +901,7 @@ NewChannelReq::Print(std::ostream& os) const
 }
 
 uint8_t
-NewChannelReq::GetChannelIndex(void)
+NewChannelReq::GetChannelIndex() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -909,7 +909,7 @@ NewChannelReq::GetChannelIndex(void)
 }
 
 double
-NewChannelReq::GetFrequency(void)
+NewChannelReq::GetFrequency() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -917,7 +917,7 @@ NewChannelReq::GetFrequency(void)
 }
 
 uint8_t
-NewChannelReq::GetMinDataRate(void)
+NewChannelReq::GetMinDataRate() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -925,7 +925,7 @@ NewChannelReq::GetMinDataRate(void)
 }
 
 uint8_t
-NewChannelReq::GetMaxDataRate(void)
+NewChannelReq::GetMaxDataRate() const
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -1044,7 +1044,7 @@ RxTimingSetupReq::Print(std::ostream& os) const
 }
 
 Time
-RxTimingSetupReq::GetDelay(void)
+RxTimingSetupReq::GetDelay()
 {
     NS_LOG_FUNCTION(this);
 

--- a/model/mac-command.h
+++ b/model/mac-command.h
@@ -65,10 +65,10 @@ enum MacCommandType
 class MacCommand : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     MacCommand();
-    virtual ~MacCommand();
+    ~MacCommand() override;
 
     /**
      * Serialize the contents of this MAC command into a buffer, according to the
@@ -98,14 +98,14 @@ class MacCommand : public Object
      *
      * \return The number of bytes the MAC command takes up.
      */
-    virtual uint8_t GetSerializedSize(void) const;
+    virtual uint8_t GetSerializedSize() const;
 
     /**
      * Get the commandType of this MAC command.
      *
      * \return The type of MAC command this object represents.
      */
-    virtual enum MacCommandType GetCommandType(void) const;
+    virtual enum MacCommandType GetCommandType() const;
 
     /**
      * Get the CID that corresponds to this MAC command.
@@ -135,10 +135,10 @@ class LinkCheckReq : public MacCommand
 {
   public:
     LinkCheckReq();
-    ~LinkCheckReq();
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    ~LinkCheckReq() override;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 };
 
 /**
@@ -153,9 +153,9 @@ class LinkCheckAns : public MacCommand
     LinkCheckAns();
     LinkCheckAns(uint8_t margin, uint8_t gwCnt);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
     /**
      * Set the demodulation margin value.
@@ -169,7 +169,7 @@ class LinkCheckAns : public MacCommand
      *
      * \return The demodulation margin value.
      */
-    uint8_t GetMargin(void) const;
+    uint8_t GetMargin() const;
 
     /**
      * Set the gateway count value.
@@ -183,12 +183,12 @@ class LinkCheckAns : public MacCommand
      *
      * \return The gateway count value.
      */
-    uint8_t GetGwCnt(void) const;
+    uint8_t GetGwCnt() const;
 
     /**
      * Increment this MacCommand's gwCnt value.
      */
-    void IncrementGwCnt(void);
+    void IncrementGwCnt();
 
   private:
     /**
@@ -220,16 +220,16 @@ class LinkAdrReq : public MacCommand
                uint8_t chMaskCntl,
                uint8_t nbRep);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
     /**
      * Return the data rate prescribed by this MAC command.
      *
      * \return An unsigned 8-bit integer containing the data rate.
      */
-    uint8_t GetDataRate(void);
+    uint8_t GetDataRate();
 
     /**
      * Get the transmission power prescribed by this MAC command.
@@ -240,7 +240,7 @@ class LinkAdrReq : public MacCommand
      *
      * \return The TX power, encoded as an unsigned 8-bit integer.
      */
-    uint8_t GetTxPower(void);
+    uint8_t GetTxPower();
 
     /**
      * Get the list of enabled channels. This method takes the 16-bit channel mask
@@ -248,14 +248,14 @@ class LinkAdrReq : public MacCommand
      *
      * \return The list of enabled channels.
      */
-    std::list<int> GetEnabledChannelsList(void);
+    std::list<int> GetEnabledChannelsList();
 
     /**
      * Get the number of repetitions prescribed by this MAC command.
      *
      * \return The number of repetitions.
      */
-    int GetRepetitions(void);
+    int GetRepetitions();
 
   private:
     uint8_t m_dataRate;
@@ -277,9 +277,9 @@ class LinkAdrAns : public MacCommand
 
     LinkAdrAns(bool powerAck, bool dataRateAck, bool channelMaskAck);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
   private:
     bool m_powerAck;
@@ -305,16 +305,16 @@ class DutyCycleReq : public MacCommand
      */
     DutyCycleReq(uint8_t dutyCycle);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
     /**
      * Get the maximum duty cycle prescribed by this Mac command, in fraction form.
      *
      * \return The maximum duty cycle.
      */
-    double GetMaximumAllowedDutyCycle(void) const;
+    double GetMaximumAllowedDutyCycle() const;
 
   private:
     uint8_t m_maxDCycle;
@@ -330,9 +330,9 @@ class DutyCycleAns : public MacCommand
   public:
     DutyCycleAns();
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 };
 
 /**
@@ -352,30 +352,30 @@ class RxParamSetupReq : public MacCommand
      */
     RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
     /**
      * Get this command's Rx1DrOffset parameter.
      *
      * \return The Rx1DrOffset parameter.
      */
-    uint8_t GetRx1DrOffset(void);
+    uint8_t GetRx1DrOffset();
 
     /**
      * Get this command's Rx2DataRate parameter.
      *
      * \return The Rx2DataRate parameter.
      */
-    uint8_t GetRx2DataRate(void);
+    uint8_t GetRx2DataRate();
 
     /**
      * Get this command's frequency.
      *
      * \return The frequency parameter, in Hz.
      */
-    double GetFrequency(void);
+    double GetFrequency();
 
   private:
     uint8_t m_rx1DrOffset;
@@ -399,9 +399,9 @@ class RxParamSetupAns : public MacCommand
      */
     RxParamSetupAns(bool rx1DrOffsetAck, bool rx2DataRateAck, bool channelAck);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
   private:
     bool m_rx1DrOffsetAck;
@@ -417,9 +417,9 @@ class DevStatusReq : public MacCommand
   public:
     DevStatusReq();
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 };
 
 /**
@@ -437,23 +437,23 @@ class DevStatusAns : public MacCommand
      */
     DevStatusAns(uint8_t battery, uint8_t margin);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
     /**
      * Get the battery information contained in this MAC command.
      *
      * \return The battery level.
      */
-    uint8_t GetBattery(void);
+    uint8_t GetBattery() const;
 
     /**
      * Get the demodulation margin contained in this MAC command.
      *
      * \return The margin.
      */
-    uint8_t GetMargin(void);
+    uint8_t GetMargin() const;
 
   private:
     uint8_t m_battery;
@@ -478,14 +478,14 @@ class NewChannelReq : public MacCommand
      */
     NewChannelReq(uint8_t chIndex, double frequency, uint8_t minDataRate, uint8_t maxDataRate);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
-    uint8_t GetChannelIndex(void);
-    double GetFrequency(void);
-    uint8_t GetMinDataRate(void);
-    uint8_t GetMaxDataRate(void);
+    uint8_t GetChannelIndex() const;
+    double GetFrequency() const;
+    uint8_t GetMinDataRate() const;
+    uint8_t GetMaxDataRate() const;
 
   private:
     uint8_t m_chIndex;
@@ -512,9 +512,9 @@ class NewChannelAns : public MacCommand
      */
     NewChannelAns(bool dataRateRangeOk, bool channelFrequencyOk);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
   private:
     bool m_dataRateRangeOk;
@@ -536,16 +536,16 @@ class RxTimingSetupReq : public MacCommand
      */
     RxTimingSetupReq(uint8_t delay);
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
     /**
      * Get the first window delay as a Time instance.
      *
      * \return The delay.
      */
-    Time GetDelay(void);
+    Time GetDelay();
 
   private:
     uint8_t m_delay;
@@ -561,9 +561,9 @@ class RxTimingSetupAns : public MacCommand
   public:
     RxTimingSetupAns();
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
   private:
 };
@@ -576,9 +576,9 @@ class TxParamSetupAns : public MacCommand
   public:
     TxParamSetupAns();
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
   private:
 };
@@ -591,9 +591,9 @@ class TxParamSetupReq : public MacCommand
   public:
     TxParamSetupReq();
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
   private:
 };
@@ -606,9 +606,9 @@ class DlChannelAns : public MacCommand
   public:
     DlChannelAns();
 
-    virtual void Serialize(Buffer::Iterator& start) const;
-    virtual uint8_t Deserialize(Buffer::Iterator& start);
-    virtual void Print(std::ostream& os) const;
+    void Serialize(Buffer::Iterator& start) const override;
+    uint8_t Deserialize(Buffer::Iterator& start) override;
+    void Print(std::ostream& os) const override;
 
   private:
 };

--- a/model/network-controller-components.cc
+++ b/model/network-controller-components.cc
@@ -29,7 +29,7 @@ NS_LOG_COMPONENT_DEFINE("NetworkControllerComponent");
 NS_OBJECT_ENSURE_REGISTERED(NetworkControllerComponent);
 
 TypeId
-NetworkControllerComponent::GetTypeId(void)
+NetworkControllerComponent::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::NetworkControllerComponent").SetParent<Object>().SetGroupName("lorawan");
@@ -49,7 +49,7 @@ NetworkControllerComponent::~NetworkControllerComponent()
 // ConfirmedMessagesComponent //
 ////////////////////////////////
 TypeId
-ConfirmedMessagesComponent::GetTypeId(void)
+ConfirmedMessagesComponent::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::ConfirmedMessagesComponent")
                             .SetParent<NetworkControllerComponent>()
@@ -127,7 +127,7 @@ ConfirmedMessagesComponent::OnFailedReply(Ptr<EndDeviceStatus> status,
 // LinkCheckComponent //
 ////////////////////////
 TypeId
-LinkCheckComponent::GetTypeId(void)
+LinkCheckComponent::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::LinkCheckComponent")
                             .SetParent<NetworkControllerComponent>()

--- a/model/network-controller-components.h
+++ b/model/network-controller-components.h
@@ -47,11 +47,11 @@ class NetworkStatus;
 class NetworkControllerComponent : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     // Constructor and destructor
     NetworkControllerComponent();
-    virtual ~NetworkControllerComponent();
+    ~NetworkControllerComponent() override;
 
     // Virtual methods whose implementation is left to child classes
     /**
@@ -84,11 +84,11 @@ class NetworkControllerComponent : public Object
 class ConfirmedMessagesComponent : public NetworkControllerComponent
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     // Constructor and destructor
     ConfirmedMessagesComponent();
-    virtual ~ConfirmedMessagesComponent();
+    ~ConfirmedMessagesComponent() override;
 
     /**
      * This method checks whether the received packet requires an acknowledgment
@@ -99,11 +99,11 @@ class ConfirmedMessagesComponent : public NetworkControllerComponent
      */
     void OnReceivedPacket(Ptr<const Packet> packet,
                           Ptr<EndDeviceStatus> status,
-                          Ptr<NetworkStatus> networkStatus);
+                          Ptr<NetworkStatus> networkStatus) override;
 
-    void BeforeSendingReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus);
+    void BeforeSendingReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus) override;
 
-    void OnFailedReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus);
+    void OnFailedReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus) override;
 };
 
 ///////////////////////////////////
@@ -113,11 +113,11 @@ class ConfirmedMessagesComponent : public NetworkControllerComponent
 class LinkCheckComponent : public NetworkControllerComponent
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     // Constructor and destructor
     LinkCheckComponent();
-    virtual ~LinkCheckComponent();
+    ~LinkCheckComponent() override;
 
     /**
      * This method checks whether the received packet requires an acknowledgment
@@ -128,11 +128,11 @@ class LinkCheckComponent : public NetworkControllerComponent
      */
     void OnReceivedPacket(Ptr<const Packet> packet,
                           Ptr<EndDeviceStatus> status,
-                          Ptr<NetworkStatus> networkStatus);
+                          Ptr<NetworkStatus> networkStatus) override;
 
-    void BeforeSendingReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus);
+    void BeforeSendingReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus) override;
 
-    void OnFailedReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus);
+    void OnFailedReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> networkStatus) override;
 
   private:
     void UpdateLinkCheckAns(Ptr<const Packet> packet, Ptr<EndDeviceStatus> status);

--- a/model/network-controller.cc
+++ b/model/network-controller.cc
@@ -29,7 +29,7 @@ NS_LOG_COMPONENT_DEFINE("NetworkController");
 NS_OBJECT_ENSURE_REGISTERED(NetworkController);
 
 TypeId
-NetworkController::GetTypeId(void)
+NetworkController::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::NetworkController")
                             .SetParent<Object>()

--- a/model/network-controller.h
+++ b/model/network-controller.h
@@ -42,11 +42,11 @@ class NetworkControllerComponent;
 class NetworkController : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     NetworkController();
     NetworkController(Ptr<NetworkStatus> networkStatus);
-    virtual ~NetworkController();
+    ~NetworkController() override;
 
     /**
      * Add a new NetworkControllerComponent

--- a/model/network-scheduler.cc
+++ b/model/network-scheduler.cc
@@ -10,7 +10,7 @@ NS_LOG_COMPONENT_DEFINE("NetworkScheduler");
 NS_OBJECT_ENSURE_REGISTERED(NetworkScheduler);
 
 TypeId
-NetworkScheduler::GetTypeId(void)
+NetworkScheduler::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::NetworkScheduler")

--- a/model/network-scheduler.h
+++ b/model/network-scheduler.h
@@ -41,11 +41,11 @@ class NetworkController; // Forward declaration
 class NetworkScheduler : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     NetworkScheduler();
     NetworkScheduler(Ptr<NetworkStatus> status, Ptr<NetworkController> controller);
-    virtual ~NetworkScheduler();
+    ~NetworkScheduler() override;
 
     /**
      * Method called by NetworkServer to inform the Scheduler of a newly arrived

--- a/model/network-server.cc
+++ b/model/network-server.cc
@@ -42,7 +42,7 @@ NS_LOG_COMPONENT_DEFINE("NetworkServer");
 NS_OBJECT_ENSURE_REGISTERED(NetworkServer);
 
 TypeId
-NetworkServer::GetTypeId(void)
+NetworkServer::GetTypeId()
 {
     static TypeId tid =
         TypeId("ns3::NetworkServer")
@@ -71,13 +71,13 @@ NetworkServer::~NetworkServer()
 }
 
 void
-NetworkServer::StartApplication(void)
+NetworkServer::StartApplication()
 {
     NS_LOG_FUNCTION_NOARGS();
 }
 
 void
-NetworkServer::StopApplication(void)
+NetworkServer::StopApplication()
 {
     NS_LOG_FUNCTION_NOARGS();
 }
@@ -186,7 +186,7 @@ NetworkServer::AddComponent(Ptr<NetworkControllerComponent> component)
 }
 
 Ptr<NetworkStatus>
-NetworkServer::GetNetworkStatus(void)
+NetworkServer::GetNetworkStatus()
 {
     return m_status;
 }

--- a/model/network-server.h
+++ b/model/network-server.h
@@ -51,20 +51,20 @@ namespace lorawan
 class NetworkServer : public Application
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     NetworkServer();
-    virtual ~NetworkServer();
+    ~NetworkServer() override;
 
     /**
      * Start the NS application.
      */
-    void StartApplication(void);
+    void StartApplication() override;
 
     /**
      * Stop the NS application.
      */
-    void StopApplication(void);
+    void StopApplication() override;
 
     /**
      * Inform the NetworkServer that these nodes are connected to the network.
@@ -101,7 +101,7 @@ class NetworkServer : public Application
                  uint16_t protocol,
                  const Address& address);
 
-    Ptr<NetworkStatus> GetNetworkStatus(void);
+    Ptr<NetworkStatus> GetNetworkStatus();
 
   protected:
     Ptr<NetworkStatus> m_status;

--- a/model/network-status.cc
+++ b/model/network-status.cc
@@ -40,7 +40,7 @@ NS_LOG_COMPONENT_DEFINE("NetworkStatus");
 NS_OBJECT_ENSURE_REGISTERED(NetworkStatus);
 
 TypeId
-NetworkStatus::GetTypeId(void)
+NetworkStatus::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::NetworkStatus")
                             .SetParent<Object>()
@@ -218,7 +218,7 @@ NetworkStatus::GetEndDeviceStatus(Ptr<const Packet> packet)
     else
     {
         NS_LOG_ERROR("EndDeviceStatus not found");
-        return 0;
+        return nullptr;
     }
 }
 
@@ -235,12 +235,12 @@ NetworkStatus::GetEndDeviceStatus(LoraDeviceAddress address)
     else
     {
         NS_LOG_ERROR("EndDeviceStatus not found");
-        return 0;
+        return nullptr;
     }
 }
 
 int
-NetworkStatus::CountEndDevices(void)
+NetworkStatus::CountEndDevices()
 {
     NS_LOG_FUNCTION(this);
 

--- a/model/network-status.h
+++ b/model/network-status.h
@@ -46,10 +46,10 @@ namespace lorawan
 class NetworkStatus : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     NetworkStatus();
-    virtual ~NetworkStatus();
+    ~NetworkStatus() override;
 
     /**
      * Add a device to the ones that are tracked by this NetworkStatus object.
@@ -113,7 +113,7 @@ class NetworkStatus : public Object
     /**
      * Return the number of end devices currently managed by the server.
      */
-    int CountEndDevices(void);
+    int CountEndDevices();
 
   public:
     std::map<LoraDeviceAddress, Ptr<EndDeviceStatus>> m_endDeviceStatuses;

--- a/model/one-shot-sender.cc
+++ b/model/one-shot-sender.cc
@@ -37,7 +37,7 @@ NS_LOG_COMPONENT_DEFINE("OneShotSender");
 NS_OBJECT_ENSURE_REGISTERED(OneShotSender);
 
 TypeId
-OneShotSender::GetTypeId(void)
+OneShotSender::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::OneShotSender")
                             .SetParent<Application>()
@@ -71,7 +71,7 @@ OneShotSender::SetSendTime(Time sendTime)
 }
 
 void
-OneShotSender::SendPacket(void)
+OneShotSender::SendPacket()
 {
     NS_LOG_FUNCTION(this);
 
@@ -81,7 +81,7 @@ OneShotSender::SendPacket(void)
 }
 
 void
-OneShotSender::StartApplication(void)
+OneShotSender::StartApplication()
 {
     NS_LOG_FUNCTION(this);
 
@@ -101,7 +101,7 @@ OneShotSender::StartApplication(void)
 }
 
 void
-OneShotSender::StopApplication(void)
+OneShotSender::StopApplication()
 {
     NS_LOG_FUNCTION_NOARGS();
     Simulator::Cancel(m_sendEvent);

--- a/model/one-shot-sender.h
+++ b/model/one-shot-sender.h
@@ -36,14 +36,14 @@ class OneShotSender : public Application
   public:
     OneShotSender();
     OneShotSender(Time sendTime);
-    ~OneShotSender();
+    ~OneShotSender() override;
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     /**
      * Send a packet using the LoraNetDevice's Send method.
      */
-    void SendPacket(void);
+    void SendPacket();
 
     /**
      * Set the time at which this app will send a packet.
@@ -53,12 +53,12 @@ class OneShotSender : public Application
     /**
      * Start the application by scheduling the first SendPacket event.
      */
-    void StartApplication(void);
+    void StartApplication() override;
 
     /**
      * Stop the application.
      */
-    void StopApplication(void);
+    void StopApplication() override;
 
   private:
     /**

--- a/model/periodic-sender.cc
+++ b/model/periodic-sender.cc
@@ -36,7 +36,7 @@ NS_LOG_COMPONENT_DEFINE("PeriodicSender");
 NS_OBJECT_ENSURE_REGISTERED(PeriodicSender);
 
 TypeId
-PeriodicSender::GetTypeId(void)
+PeriodicSender::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::PeriodicSender")
                             .SetParent<Application>()
@@ -60,7 +60,7 @@ PeriodicSender::PeriodicSender()
     : m_interval(Seconds(10)),
       m_initialDelay(Seconds(1)),
       m_basePktSize(10),
-      m_pktSizeRV(0)
+      m_pktSizeRV(nullptr)
 
 {
     NS_LOG_FUNCTION_NOARGS();
@@ -79,7 +79,7 @@ PeriodicSender::SetInterval(Time interval)
 }
 
 Time
-PeriodicSender::GetInterval(void) const
+PeriodicSender::GetInterval() const
 {
     NS_LOG_FUNCTION(this);
     return m_interval;
@@ -105,7 +105,7 @@ PeriodicSender::SetPacketSize(uint8_t size)
 }
 
 void
-PeriodicSender::SendPacket(void)
+PeriodicSender::SendPacket()
 {
     NS_LOG_FUNCTION(this);
 
@@ -129,7 +129,7 @@ PeriodicSender::SendPacket(void)
 }
 
 void
-PeriodicSender::StartApplication(void)
+PeriodicSender::StartApplication()
 {
     NS_LOG_FUNCTION(this);
 
@@ -152,7 +152,7 @@ PeriodicSender::StartApplication(void)
 }
 
 void
-PeriodicSender::StopApplication(void)
+PeriodicSender::StopApplication()
 {
     NS_LOG_FUNCTION_NOARGS();
     Simulator::Cancel(m_sendEvent);

--- a/model/periodic-sender.h
+++ b/model/periodic-sender.h
@@ -35,9 +35,9 @@ class PeriodicSender : public Application
 {
   public:
     PeriodicSender();
-    ~PeriodicSender();
+    ~PeriodicSender() override;
 
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     /**
      * Set the sending interval
@@ -49,7 +49,7 @@ class PeriodicSender : public Application
      * Get the sending interval
      * \returns the interval between two packet sends
      */
-    Time GetInterval(void) const;
+    Time GetInterval() const;
 
     /**
      * Set the initial delay of this application
@@ -69,17 +69,17 @@ class PeriodicSender : public Application
     /**
      * Send a packet using the LoraNetDevice's Send method
      */
-    void SendPacket(void);
+    void SendPacket();
 
     /**
      * Start the application by scheduling the first SendPacket event
      */
-    void StartApplication(void);
+    void StartApplication() override;
 
     /**
      * Stop the application
      */
-    void StopApplication(void);
+    void StopApplication() override;
 
   private:
     /**

--- a/model/simple-end-device-lora-phy.cc
+++ b/model/simple-end-device-lora-phy.cc
@@ -36,7 +36,7 @@ NS_LOG_COMPONENT_DEFINE("SimpleEndDeviceLoraPhy");
 NS_OBJECT_ENSURE_REGISTERED(SimpleEndDeviceLoraPhy);
 
 TypeId
-SimpleEndDeviceLoraPhy::GetTypeId(void)
+SimpleEndDeviceLoraPhy::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::SimpleEndDeviceLoraPhy")
                             .SetParent<EndDeviceLoraPhy>()

--- a/model/simple-end-device-lora-phy.h
+++ b/model/simple-end-device-lora-phy.h
@@ -43,27 +43,27 @@ class LoraChannel;
 class SimpleEndDeviceLoraPhy : public EndDeviceLoraPhy
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     // Constructor and destructor
     SimpleEndDeviceLoraPhy();
-    virtual ~SimpleEndDeviceLoraPhy();
+    ~SimpleEndDeviceLoraPhy() override;
 
     // Implementation of EndDeviceLoraPhy's pure virtual functions
-    virtual void StartReceive(Ptr<Packet> packet,
-                              double rxPowerDbm,
-                              uint8_t sf,
-                              Time duration,
-                              double frequencyMHz);
+    void StartReceive(Ptr<Packet> packet,
+                      double rxPowerDbm,
+                      uint8_t sf,
+                      Time duration,
+                      double frequencyMHz) override;
 
     // Implementation of LoraPhy's pure virtual functions
-    virtual void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event);
+    void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) override;
 
     // Implementation of LoraPhy's pure virtual functions
-    virtual void Send(Ptr<Packet> packet,
-                      LoraTxParameters txParams,
-                      double frequencyMHz,
-                      double txPowerDbm);
+    void Send(Ptr<Packet> packet,
+              LoraTxParameters txParams,
+              double frequencyMHz,
+              double txPowerDbm) override;
 
   private:
 };

--- a/model/simple-gateway-lora-phy.cc
+++ b/model/simple-gateway-lora-phy.cc
@@ -38,7 +38,7 @@ NS_OBJECT_ENSURE_REGISTERED(SimpleGatewayLoraPhy);
  ***********************************************************************/
 
 TypeId
-SimpleGatewayLoraPhy::GetTypeId(void)
+SimpleGatewayLoraPhy::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::SimpleGatewayLoraPhy")
                             .SetParent<GatewayLoraPhy>()

--- a/model/simple-gateway-lora-phy.h
+++ b/model/simple-gateway-lora-phy.h
@@ -44,23 +44,23 @@ class LoraChannel;
 class SimpleGatewayLoraPhy : public GatewayLoraPhy
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     SimpleGatewayLoraPhy();
-    virtual ~SimpleGatewayLoraPhy();
+    ~SimpleGatewayLoraPhy() override;
 
-    virtual void StartReceive(Ptr<Packet> packet,
-                              double rxPowerDbm,
-                              uint8_t sf,
-                              Time duration,
-                              double frequencyMHz);
+    void StartReceive(Ptr<Packet> packet,
+                      double rxPowerDbm,
+                      uint8_t sf,
+                      Time duration,
+                      double frequencyMHz) override;
 
-    virtual void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event);
+    void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) override;
 
-    virtual void Send(Ptr<Packet> packet,
-                      LoraTxParameters txParams,
-                      double frequencyMHz,
-                      double txPowerDbm);
+    void Send(Ptr<Packet> packet,
+              LoraTxParameters txParams,
+              double frequencyMHz,
+              double txPowerDbm) override;
 
   private:
 };

--- a/model/sub-band.cc
+++ b/model/sub-band.cc
@@ -31,7 +31,7 @@ NS_LOG_COMPONENT_DEFINE("SubBand");
 NS_OBJECT_ENSURE_REGISTERED(SubBand);
 
 TypeId
-SubBand::GetTypeId(void)
+SubBand::GetTypeId()
 {
     static TypeId tid = TypeId("ns3::SubBand").SetParent<Object>().SetGroupName("lorawan");
     return tid;
@@ -61,25 +61,25 @@ SubBand::~SubBand()
 }
 
 double
-SubBand::GetFirstFrequency(void)
+SubBand::GetFirstFrequency() const
 {
     return m_firstFrequency;
 }
 
 double
-SubBand::GetDutyCycle(void)
+SubBand::GetDutyCycle() const
 {
     return m_dutyCycle;
 }
 
 bool
-SubBand::BelongsToSubBand(double frequency)
+SubBand::BelongsToSubBand(double frequency) const
 {
     return (frequency > m_firstFrequency) && (frequency < m_lastFrequency);
 }
 
 bool
-SubBand::BelongsToSubBand(Ptr<LogicalLoraChannel> logicalChannel)
+SubBand::BelongsToSubBand(Ptr<LogicalLoraChannel> logicalChannel) const
 {
     double frequency = logicalChannel->GetFrequency();
     return BelongsToSubBand(frequency);
@@ -92,7 +92,7 @@ SubBand::SetNextTransmissionTime(Time nextTime)
 }
 
 Time
-SubBand::GetNextTransmissionTime(void)
+SubBand::GetNextTransmissionTime()
 {
     return m_nextTransmissionTime;
 }
@@ -104,7 +104,7 @@ SubBand::SetMaxTxPowerDbm(double maxTxPowerDbm)
 }
 
 double
-SubBand::GetMaxTxPowerDbm(void)
+SubBand::GetMaxTxPowerDbm() const
 {
     return m_maxTxPowerDbm;
 }

--- a/model/sub-band.h
+++ b/model/sub-band.h
@@ -39,7 +39,7 @@ class LogicalLoraChannel;
 class SubBand : public Object
 {
   public:
-    static TypeId GetTypeId(void);
+    static TypeId GetTypeId();
 
     SubBand();
 
@@ -53,21 +53,21 @@ class SubBand : public Object
      */
     SubBand(double firstFrequency, double lastFrequency, double dutyCycle, double maxTxPowerDbm);
 
-    virtual ~SubBand();
+    ~SubBand() override;
 
     /**
      * Get the lowest frequency of the SubBand.
      *
      * \return The lowest frequency of the SubBand.
      */
-    double GetFirstFrequency(void);
+    double GetFirstFrequency() const;
 
     /**
      * Get the last frequency of the subband.
      *
      * \return The lowest frequency of the SubBand.
      */
-    // double GetLastFrequency (void);
+    // double GetLastFrequency ();
 
     /**
      * Get the duty cycle of the subband.
@@ -75,7 +75,7 @@ class SubBand : public Object
      * \return The duty cycle (as a fraction) that needs to be enforced on this
      * SubBand.
      */
-    double GetDutyCycle(void);
+    double GetDutyCycle() const;
 
     /**
      * Update the next transmission time.
@@ -95,7 +95,7 @@ class SubBand : public Object
      * \return The next time at which transmission in this SubBand will be
      * allowed.
      */
-    Time GetNextTransmissionTime(void);
+    Time GetNextTransmissionTime();
 
     /**
      * Return whether or not a frequency belongs to this SubBand.
@@ -104,7 +104,7 @@ class SubBand : public Object
      * \return True if the frequency is between firstFrequency and lastFrequency,
      * false otherwise.
      */
-    bool BelongsToSubBand(double frequency);
+    bool BelongsToSubBand(double frequency) const;
 
     /**
      * Return whether or not a channel belongs to this SubBand.
@@ -113,7 +113,7 @@ class SubBand : public Object
      * \return True if the channel's center frequency is between firstFrequency
      * and lastFrequency, false otherwise.
      */
-    bool BelongsToSubBand(Ptr<LogicalLoraChannel> channel);
+    bool BelongsToSubBand(Ptr<LogicalLoraChannel> channel) const;
 
     /**
      * Set the maximum transmission power that is allowed on this SubBand.
@@ -127,7 +127,7 @@ class SubBand : public Object
      *
      * \return The maximum transmission power, in dBm.
      */
-    double GetMaxTxPowerDbm(void);
+    double GetMaxTxPowerDbm() const;
 
   private:
     double m_firstFrequency;     //!< Starting frequency of the subband, in MHz

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -24,10 +24,10 @@ class InterferenceTest : public TestCase
 {
   public:
     InterferenceTest();
-    virtual ~InterferenceTest();
+    ~InterferenceTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -44,7 +44,7 @@ InterferenceTest::~InterferenceTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-InterferenceTest::DoRun(void)
+InterferenceTest::DoRun()
 {
     NS_LOG_DEBUG("InterferenceTest");
 
@@ -57,29 +57,29 @@ InterferenceTest::DoRun(void)
     Ptr<LoraInterferenceHelper::Event> event1;
 
     // Test overlap duration
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    event1 = interferenceHelper.Add(Seconds(1), 14, 12, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    event1 = interferenceHelper.Add(Seconds(1), 14, 12, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(1),
                           "Overlap computation didn't give the expected result");
     interferenceHelper.ClearAllEvents();
 
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    event1 = interferenceHelper.Add(Seconds(1.5), 14, 12, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    event1 = interferenceHelper.Add(Seconds(1.5), 14, 12, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(1.5),
                           "Overlap computation didn't give the expected result");
     interferenceHelper.ClearAllEvents();
 
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    event1 = interferenceHelper.Add(Seconds(3), 14, 12, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    event1 = interferenceHelper.Add(Seconds(3), 14, 12, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(2),
                           "Overlap computation didn't give the expected result");
     interferenceHelper.ClearAllEvents();
 
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    event1 = interferenceHelper.Add(Seconds(2), 14, 12, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    event1 = interferenceHelper.Add(Seconds(2), 14, 12, nullptr, frequency);
     // Because of some strange behavior, this test would get stuck if we used the same syntax of the
     // previous ones. This works instead.
     bool retval = interferenceHelper.GetOverlapTime(event, event1) == Seconds(2);
@@ -87,32 +87,32 @@ InterferenceTest::DoRun(void)
     interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet survives
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14, 12, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14, 12, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
     interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet survives
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 - 7, 7, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 - 7, 7, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
     interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet destroyed
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 - 6, 7, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 - 6, 7, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           7,
                           "Packet was not destroyed by interference as expected");
     interferenceHelper.ClearAllEvents();
 
     // Partial overlap, packet survives
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(1), 14 - 6, 7, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(1), 14 - 6, 7, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
@@ -121,8 +121,8 @@ InterferenceTest::DoRun(void)
     // Different frequencys
     // Packet would be destroyed if they were on the same frequency, but survives
     // since they are on different frequencies
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14, 7, 0, differentFrequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14, 7, nullptr, differentFrequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
@@ -131,8 +131,8 @@ InterferenceTest::DoRun(void)
     // Different SFs
     // Packet would be destroyed if they both were SF7, but survives thanks to SF
     // orthogonality
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
@@ -140,16 +140,16 @@ InterferenceTest::DoRun(void)
 
     // SF imperfect orthogonality
     // Different SFs are orthogonal only up to a point
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 17, 8, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 17, 8, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           8,
                           "Packet was not destroyed by interference as expected");
     interferenceHelper.ClearAllEvents();
 
     // If a more 'distant' SF is used, isolation gets better
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 17, 10, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 17, 10, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet was destroyed by interference while it should have survived");
@@ -157,10 +157,10 @@ InterferenceTest::DoRun(void)
 
     // Cumulative interference
     // Same-SF interference is cumulative
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           8,
                           "Packet was not destroyed by interference as expected");
@@ -168,10 +168,10 @@ InterferenceTest::DoRun(void)
 
     // Cumulative interference
     // Interference is not cumulative between different SFs
-    event = interferenceHelper.Add(Seconds(2), 14, 7, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 9, 0, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 10, 0, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 9, nullptr, frequency);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 10, nullptr, frequency);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
@@ -186,10 +186,10 @@ class AddressTest : public TestCase
 {
   public:
     AddressTest();
-    virtual ~AddressTest();
+    ~AddressTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -206,7 +206,7 @@ AddressTest::~AddressTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-AddressTest::DoRun(void)
+AddressTest::DoRun()
 {
     NS_LOG_DEBUG("AddressTest");
 
@@ -268,10 +268,10 @@ class HeaderTest : public TestCase
 {
   public:
     HeaderTest();
-    virtual ~HeaderTest();
+    ~HeaderTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -288,7 +288,7 @@ HeaderTest::~HeaderTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-HeaderTest::DoRun(void)
+HeaderTest::DoRun()
 {
     NS_LOG_DEBUG("HeaderTest");
 
@@ -419,11 +419,11 @@ class ReceivePathTest : public TestCase
 {
   public:
     ReceivePathTest();
-    virtual ~ReceivePathTest();
+    ~ReceivePathTest() override;
 
   private:
-    virtual void DoRun(void);
-    void Reset(void);
+    void DoRun() override;
+    void Reset();
     void OccupiedReceptionPaths(int oldValue, int newValue);
     void NoMoreDemodulators(Ptr<const Packet> packet, uint32_t node);
     void Interference(Ptr<const Packet> packet, uint32_t node);
@@ -448,7 +448,7 @@ ReceivePathTest::~ReceivePathTest()
 }
 
 void
-ReceivePathTest::Reset(void)
+ReceivePathTest::Reset()
 {
     // FIXME
     // m_noMoreDemodulatorsCalls = 0;
@@ -515,7 +515,7 @@ ReceivePathTest::ReceivedPacket(Ptr<const Packet> packet, uint32_t node)
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-ReceivePathTest::DoRun(void)
+ReceivePathTest::DoRun()
 {
     NS_LOG_DEBUG("ReceivePathTest");
 
@@ -822,10 +822,10 @@ class LogicalLoraChannelTest : public TestCase
 {
   public:
     LogicalLoraChannelTest();
-    virtual ~LogicalLoraChannelTest();
+    ~LogicalLoraChannelTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -842,7 +842,7 @@ LogicalLoraChannelTest::~LogicalLoraChannelTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-LogicalLoraChannelTest::DoRun(void)
+LogicalLoraChannelTest::DoRun()
 {
     NS_LOG_DEBUG("LogicalLoraChannelTest");
 
@@ -945,10 +945,10 @@ class TimeOnAirTest : public TestCase
 {
   public:
     TimeOnAirTest();
-    virtual ~TimeOnAirTest();
+    ~TimeOnAirTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -966,7 +966,7 @@ TimeOnAirTest::~TimeOnAirTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-TimeOnAirTest::DoRun(void)
+TimeOnAirTest::DoRun()
 {
     NS_LOG_DEBUG("TimeOnAirTest");
 
@@ -985,7 +985,7 @@ TimeOnAirTest::DoRun(void)
     txParams.codingRate = 1;
     txParams.bandwidthHz = 125000;
     txParams.nPreamble = 8;
-    txParams.crcEnabled = 1;
+    txParams.crcEnabled = true;
     txParams.lowDataRateOptimizationEnabled = false;
 
     duration = LoraPhy::GetOnAirTime(packet, txParams);
@@ -1056,7 +1056,7 @@ class PhyConnectivityTest : public TestCase
 {
   public:
     PhyConnectivityTest();
-    virtual ~PhyConnectivityTest();
+    ~PhyConnectivityTest() override;
     void Reset();
     void ReceivedPacket(Ptr<const Packet> packet, uint32_t node);
     void UnderSensitivity(Ptr<const Packet> packet, uint32_t node);
@@ -1067,7 +1067,7 @@ class PhyConnectivityTest : public TestCase
     bool HaveSamePacketContents(Ptr<Packet> packet1, Ptr<Packet> packet2);
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
     Ptr<LoraChannel> channel;
     Ptr<SimpleEndDeviceLoraPhy> edPhy1;
     Ptr<SimpleEndDeviceLoraPhy> edPhy2;
@@ -1171,7 +1171,7 @@ PhyConnectivityTest::HaveSamePacketContents(Ptr<Packet> packet1, Ptr<Packet> pac
 }
 
 void
-PhyConnectivityTest::Reset(void)
+PhyConnectivityTest::Reset()
 {
     m_receivedPacketCalls = 0;
     m_underSensitivityCalls = 0;
@@ -1280,7 +1280,7 @@ PhyConnectivityTest::Reset(void)
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-PhyConnectivityTest::DoRun(void)
+PhyConnectivityTest::DoRun()
 {
     NS_LOG_DEBUG("PhyConnectivityTest");
 
@@ -1517,10 +1517,10 @@ class LorawanMacTest : public TestCase
 {
   public:
     LorawanMacTest();
-    virtual ~LorawanMacTest();
+    ~LorawanMacTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -1537,7 +1537,7 @@ LorawanMacTest::~LorawanMacTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-LorawanMacTest::DoRun(void)
+LorawanMacTest::DoRun()
 {
     NS_LOG_DEBUG("LorawanMacTest");
 }

--- a/test/network-scheduler-test-suite.cc
+++ b/test/network-scheduler-test-suite.cc
@@ -22,10 +22,10 @@ class NetworkSchedulerTest : public TestCase
 {
   public:
     NetworkSchedulerTest();
-    virtual ~NetworkSchedulerTest();
+    ~NetworkSchedulerTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -42,7 +42,7 @@ NetworkSchedulerTest::~NetworkSchedulerTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-NetworkSchedulerTest::DoRun(void)
+NetworkSchedulerTest::DoRun()
 {
     NS_LOG_DEBUG("NetworkSchedulerTest");
 

--- a/test/network-server-test-suite.cc
+++ b/test/network-server-test-suite.cc
@@ -32,13 +32,13 @@ class UplinkPacketTest : public TestCase
 {
   public:
     UplinkPacketTest();
-    virtual ~UplinkPacketTest();
+    ~UplinkPacketTest() override;
 
     void ReceivedPacket(Ptr<const Packet> packet);
     void SendPacket(Ptr<Node> endDevice);
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
     bool m_receivedPacket = false;
 };
 
@@ -70,7 +70,7 @@ UplinkPacketTest::SendPacket(Ptr<Node> endDevice)
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-UplinkPacketTest::DoRun(void)
+UplinkPacketTest::DoRun()
 {
     NS_LOG_DEBUG("UplinkPacketTest");
 
@@ -106,7 +106,7 @@ class DownlinkPacketTest : public TestCase
 {
   public:
     DownlinkPacketTest();
-    virtual ~DownlinkPacketTest();
+    ~DownlinkPacketTest() override;
 
     void ReceivedPacketAtEndDevice(uint8_t requiredTransmissions,
                                    bool success,
@@ -115,7 +115,7 @@ class DownlinkPacketTest : public TestCase
     void SendPacket(Ptr<Node> endDevice, bool requestAck);
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
     bool m_receivedPacketAtEd = false;
 };
 
@@ -158,7 +158,7 @@ DownlinkPacketTest::SendPacket(Ptr<Node> endDevice, bool requestAck)
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-DownlinkPacketTest::DoRun(void)
+DownlinkPacketTest::DoRun()
 {
     NS_LOG_DEBUG("DownlinkPacketTest");
 
@@ -198,14 +198,14 @@ class LinkCheckTest : public TestCase
 {
   public:
     LinkCheckTest();
-    virtual ~LinkCheckTest();
+    ~LinkCheckTest() override;
 
     void LastKnownGatewayCount(int newValue, int oldValue);
 
     void SendPacket(Ptr<Node> endDevice, bool requestAck);
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
     bool m_receivedPacketAtEd = false;
     int m_numberOfGatewaysThatReceivedPacket = 0;
 };
@@ -252,7 +252,7 @@ LinkCheckTest::SendPacket(Ptr<Node> endDevice, bool requestAck)
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-LinkCheckTest::DoRun(void)
+LinkCheckTest::DoRun()
 {
     NS_LOG_DEBUG("LinkCheckTest");
 

--- a/test/network-status-test-suite.cc
+++ b/test/network-status-test-suite.cc
@@ -30,10 +30,10 @@ class EndDeviceStatusTest : public TestCase
 {
   public:
     EndDeviceStatusTest();
-    virtual ~EndDeviceStatusTest();
+    ~EndDeviceStatusTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -50,7 +50,7 @@ EndDeviceStatusTest::~EndDeviceStatusTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-EndDeviceStatusTest::DoRun(void)
+EndDeviceStatusTest::DoRun()
 {
     NS_LOG_DEBUG("EndDeviceStatusTest");
 
@@ -66,10 +66,10 @@ class NetworkStatusTest : public TestCase
 {
   public:
     NetworkStatusTest();
-    virtual ~NetworkStatusTest();
+    ~NetworkStatusTest() override;
 
   private:
-    virtual void DoRun(void);
+    void DoRun() override;
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -86,7 +86,7 @@ NetworkStatusTest::~NetworkStatusTest()
 // This method is the pure virtual method from class TestCase that every
 // TestCase must implement
 void
-NetworkStatusTest::DoRun(void)
+NetworkStatusTest::DoRun()
 {
     NS_LOG_DEBUG("NetworkStatusTest");
 

--- a/test/utilities.cc
+++ b/test/utilities.cc
@@ -6,7 +6,7 @@ namespace lorawan
 {
 
 Ptr<LoraChannel>
-CreateChannel(void)
+CreateChannel()
 {
     // Create the lora channel object
     Ptr<LogDistancePropagationLossModel> loss = CreateObject<LogDistancePropagationLossModel>();
@@ -112,7 +112,7 @@ InitializeNetwork(int nDevices, int nGateways)
 
     NodeContainer gateways = CreateGateways(nGateways, mobility, channel);
 
-    LorawanMacHelper().SetSpreadingFactorsUp(endDevices, gateways, channel);
+    LorawanMacHelper::SetSpreadingFactorsUp(endDevices, gateways, channel);
 
     Ptr<Node> nsNode = CreateNetworkServer(endDevices, gateways);
 

--- a/test/utilities.h
+++ b/test/utilities.h
@@ -38,7 +38,7 @@ struct NetworkComponents
     Ptr<Node> nsNode;
 };
 
-Ptr<LoraChannel> CreateChannel(void);
+Ptr<LoraChannel> CreateChannel();
 
 NodeContainer CreateEndDevices(int nDevices, MobilityHelper mobility, Ptr<LoraChannel> channel);
 


### PR DESCRIPTION
Apply [ns-3 .clang-tidy linting rules](https://gitlab.com/nsnam/ns-3-dev/-/blob/ecd3874a2490849fd6f6d126b27f327f7418c8ab/.clang-tidy) to all files of the module.

Changes were applied automatically by running the combination of commands shown [here](https://github.com/non-det-alle/lorawan/blob/16d1ed6e2cff6a867d417c622efe84e4e4440a19/.github/workflows/.code-linting.yml#L46C1-L54C23) with the additional `-fix` option of `clang-tidy-diff`. 

This merge is meant to break up a previous [huge pull request](https://github.com/signetlabdei/lorawan/pull/135) into more digestible pieces.