### PR TITLE
Add licence to test files and examples + fix missing copyrights

### DIFF
--- a/examples/adr-example.cc
+++ b/examples/adr-example.cc
@@ -1,4 +1,23 @@
 /*
+ * Copyright (c) 2018 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This program creates a simple network which uses an ADR algorithm to set up
  * the Spreading Factors of the devices in the Network.
  */

--- a/examples/aloha-throughput.cc
+++ b/examples/aloha-throughput.cc
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2017 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
 #include "ns3/building-allocator.h"
 #include "ns3/building-penetration-loss.h"
 #include "ns3/buildings-helper.h"

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -1,4 +1,23 @@
 /*
+ * Copyright (c) 2017 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This script simulates a complex scenario with multiple gateways and end
  * devices. The metric of interest for this script is the throughput of the
  * network.

--- a/examples/frame-counter-update.cc
+++ b/examples/frame-counter-update.cc
@@ -1,4 +1,23 @@
 /*
+ * Copyright (c) 2017 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This script simulates a complex scenario with multiple gateways and end
  * devices. The metric of interest for this script is the throughput of the
  * network.

--- a/examples/lorawan-energy-model-example.cc
+++ b/examples/lorawan-energy-model-example.cc
@@ -1,4 +1,23 @@
 /*
+ * Copyright (c) 2017 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This script simulates a simple network to explain how the Lora energy model
  * works.
  */

--- a/examples/network-server-example.cc
+++ b/examples/network-server-example.cc
@@ -1,4 +1,23 @@
 /*
+ * Copyright (c) 2017 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This example creates a simple network in which all LoRaWAN components are
  * simulated: End Devices, some Gateways and a Network Server.
  * Two end devices are already configured to send unconfirmed and confirmed messages respectively.

--- a/examples/parallel-reception-example.cc
+++ b/examples/parallel-reception-example.cc
@@ -1,4 +1,23 @@
 /*
+ * Copyright (c) 2017 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This script simulates a simple network in which one end device sends one
  * packet to the gateway.
  */

--- a/examples/simple-network-example.cc
+++ b/examples/simple-network-example.cc
@@ -1,4 +1,23 @@
 /*
+ * Copyright (c) 2017 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This script simulates a simple network in which one end device sends one
  * packet to the gateway.
  */

--- a/helper/lora-radio-energy-model-helper.cc
+++ b/helper/lora-radio-energy-model-helper.cc
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2017 University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as

--- a/helper/lora-radio-energy-model-helper.h
+++ b/helper/lora-radio-energy-model-helper.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2017 University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as

--- a/model/lora-radio-energy-model.cc
+++ b/model/lora-radio-energy-model.cc
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2017 University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -9,6 +10,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  * Author: Romagnolo Stefano <romagnolostefano93@gmail.com>
  */

--- a/model/lora-radio-energy-model.h
+++ b/model/lora-radio-energy-model.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2017 University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -8,6 +9,10 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  * Authors: Romagnolo Stefano <romagnolostefano93@gmail.com>
  *          Davide Magrin <magrinda@dei.unipd.it>

--- a/model/lora-tx-current-model.cc
+++ b/model/lora-tx-current-model.cc
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2017 University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -8,6 +9,10 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  * Author: Romagnolo Stefano <romagnolostefano93@gmail.com>
  */

--- a/model/lora-tx-current-model.h
+++ b/model/lora-tx-current-model.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2017 University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -8,6 +9,10 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  * Authors: Romagnolo Stefano <romagnolostefano93@gmail.com>
  *          Davide Magrin <magrinda@dei.unipd.it>

--- a/model/lora-utils.cc
+++ b/model/lora-utils.cc
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2017 University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -8,6 +9,10 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  * Author: Romagnolo Stefano <romagnolostefano93@gmail.com>
  */

--- a/model/lora-utils.h
+++ b/model/lora-utils.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2017 University of Padova
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -8,6 +9,10 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  * Author: Romagnolo Stefano <romagnolostefano93@gmail.com>
  */

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
 
 // Include headers of classes to test
 #include "ns3/constant-position-mobility-model.h"

--- a/test/network-scheduler-test-suite.cc
+++ b/test/network-scheduler-test-suite.cc
@@ -1,4 +1,19 @@
 /*
+ * Copyright (c) 2018 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
  * Author: Davide Magrin <magrinda@dei.unipd.it>
  */
 

--- a/test/network-server-test-suite.cc
+++ b/test/network-server-test-suite.cc
@@ -1,10 +1,27 @@
 /*
+ * Copyright (c) 2018 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This file includes testing for the following components:
  * - EndDeviceServer
  * - GatewayServer
  * - NetworkServer
- *
- * Author: Davide Magrin <magrinda@dei.unipd.it>
  */
 
 // Include headers of classes to test

--- a/test/network-status-test-suite.cc
+++ b/test/network-status-test-suite.cc
@@ -1,10 +1,27 @@
 /*
+ * Copyright (c) 2018 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
+/*
  * This file includes testing for the following components:
  * - EndDeviceStatus
  * - GatewayStatus
  * - NetworkStatus
- *
- * Author: Davide Magrin <magrinda@dei.unipd.it>
  */
 
 // Include headers of classes to test

--- a/test/utilities.cc
+++ b/test/utilities.cc
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2018 University of Padova
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Davide Magrin <magrinda@dei.unipd.it>
+ */
+
 #include "utilities.h"
 
 namespace ns3

--- a/test/utilities.h
+++ b/test/utilities.h
@@ -16,6 +16,7 @@
  *
  * Authors: Davide Magrin <magrinda@dei.unipd.it>
  */
+
 #ifndef TEST_UTILITIES_H
 #define TEST_UTILITIES_H
 


### PR DESCRIPTION
Compared with the other modules in the ns-3 source, we are missing licences in the test and example files. Moreover, some licences were uncomplete and were missing copyrights. This pull is an effort to fix these things.

Git logs were used to choose the proper year for missing copyrights.