### PR TITLE
proposition to fix #163

### DIFF
--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -203,8 +203,9 @@ EndDeviceLorawanMac::postponeTransmission(Time netxTxDelay, Ptr<Packet> packet)
     if (packet == m_retxParams.packet)
     {
         m_nextTx = eid;
-    } // this is not a retransmission 
-    else {
+    } // this is not a retransmission
+    else
+    {
         m_nextTx = EventId();
     }
     NS_LOG_WARN("Attempting to send, but the aggregate duty cycle won't allow it. Scheduling a tx "

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -198,7 +198,15 @@ EndDeviceLorawanMac::postponeTransmission(Time netxTxDelay, Ptr<Packet> packet)
     NS_LOG_FUNCTION(this);
     // Delete previously scheduled transmissions if any.
     Simulator::Cancel(m_nextTx);
-    m_nextTx = Simulator::Schedule(netxTxDelay, &EndDeviceLorawanMac::DoSend, this, packet);
+    EventId eid = Simulator::Schedule(netxTxDelay, &EndDeviceLorawanMac::Send, this, packet);
+    // Checking if this is the transmission of a new packet
+    if (packet == m_retxParams.packet)
+    {
+        m_nextTx = eid;
+    } // this is not a retransmission 
+    else {
+        m_nextTx = EventId();
+    }
     NS_LOG_WARN("Attempting to send, but the aggregate duty cycle won't allow it. Scheduling a tx "
                 "at a delay "
                 << netxTxDelay.GetSeconds() << ".");
@@ -619,6 +627,7 @@ EndDeviceLorawanMac::Shuffle(std::vector<Ptr<LogicalLoraChannel>> vector)
 void
 EndDeviceLorawanMac::resetRetransmissionParameters()
 {
+    NS_LOG_FUNCTION(this);
     m_retxParams.waitingAck = false;
     m_retxParams.retxLeft = m_maxNumbTx;
     m_retxParams.packet = nullptr;


### PR DESCRIPTION
This pull request fixes issue #163

## Proposed Changes

  - Check nextTx is indeed a retransmission before assigning it to ensure we won't cancel another type of event
  - Schedule a new Send instead of doSend to recheck if the channel is available or if another delay has to be applied
  - Add debug log line at start of resetRetransmissionParameters
  
This does not break the tests, but tell me if it is a problem for another part of the LoRa code (I am still figuring out some of it)
