### PR TITLE
Fixed broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to perform simulations of a [LoRaWAN](https://lora-alliance.org/about-lorawan
 
 [Module Documentation](https://signetlabdei.github.io/lorawan-docs/models/build/html/lorawan.html).
 
-[Doxygen API Documentation](https://signetlabdei.github.io/lorawan-docs/html/index.html).
+[Doxygen API Documentation](https://www.nsnam.org/docs/doxygen/index.html).
 
 ## Getting started ##
 


### PR DESCRIPTION

This pull request fixes issue #160 

## Proposed Changes

  - Fixed the broken link pointing to official `ns-3 Doxygen`  :  **Documentation of the public APIs of the simulator** 
  
     https://www.nsnam.org/docs/doxygen/index.html


