### PR TITLE
Keep minimal dependencies in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,12 +104,9 @@ build_lib(
   SOURCE_FILES ${source_files}
   HEADER_FILES ${header_files}
   LIBRARIES_TO_LINK
-    ${libnetwork}
-    ${libpropagation}
     ${libenergy}
     ${libpoint-to-point}
     ${libbuildings}
-    ${libmobility}
   TEST_SOURCES
     test/utilities.cc
     test/lorawan-test-suite.cc


### PR DESCRIPTION
Only keep minimal module dependency list in root CMakeList.txt, as done in other ns-3 main modules.

This PR is an effort to break #135 into more digestible pieces.