### PR TITLE
Loop file names in examples' CMakeLists.txt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,55 +1,21 @@
-build_lib_example(
-  NAME simple-network-example
-  SOURCE_FILES simple-network-example.cc
-  LIBRARIES_TO_LINK ${libcore}
-                    ${liblorawan}
+set(base_examples
+    simple-network-example
+    network-server-example
+    complete-network-example
+    adr-example
+    lorawan-energy-model-example
+    aloha-throughput
+    parallel-reception-example
+    frame-counter-update
 )
 
-build_lib_example(
-  NAME network-server-example
-  SOURCE_FILES network-server-example.cc
-  LIBRARIES_TO_LINK ${libcore}
-                    ${liblorawan}
+foreach(
+  example
+  ${base_examples}
 )
-
-build_lib_example(
-  NAME complete-network-example
-  SOURCE_FILES complete-network-example.cc
-  LIBRARIES_TO_LINK ${libcore}
-                    ${liblorawan}
-)
-
-build_lib_example(
-  NAME adr-example
-  SOURCE_FILES adr-example.cc
-  LIBRARIES_TO_LINK ${libcore}
-                    ${liblorawan}
-)
-
-build_lib_example(
-  NAME lorawan-energy-model-example
-  SOURCE_FILES lorawan-energy-model-example.cc
-  LIBRARIES_TO_LINK ${libcore}
-                    ${liblorawan}
-)
-
-build_lib_example(
-  NAME aloha-throughput
-  SOURCE_FILES aloha-throughput.cc
-  LIBRARIES_TO_LINK ${libcore}
-                    ${liblorawan}
-)
-
-build_lib_example(
-  NAME parallel-reception-example
-  SOURCE_FILES parallel-reception-example.cc
-  LIBRARIES_TO_LINK ${libcore}
-                    ${liblorawan}
-)
-
-build_lib_example(
-  NAME frame-counter-update
-  SOURCE_FILES frame-counter-update.cc
-  LIBRARIES_TO_LINK ${libcore}
-                    ${liblorawan}
-)
+  build_lib_example(
+    NAME ${example}
+    SOURCE_FILES ${example}.cc
+    LIBRARIES_TO_LINK ${liblorawan}
+  )
+endforeach()


### PR DESCRIPTION
Use a cmake loop to simplify the examples' CMakeList.txt file (idea taken from `lr-wpan` module).

This PR is an effort to break #135 into more digestible pieces.