### PR TITLE
Prefer explicit DynamicCast in place of GetObject for downcasting

### DIFF
--- a/examples/aloha-throughput.cc
+++ b/examples/aloha-throughput.cc
@@ -222,7 +222,7 @@ main(int argc, char* argv[])
     for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> node = *j;
-        Ptr<LoraNetDevice> loraNetDevice = node->GetDevice(0)->GetObject<LoraNetDevice>();
+        Ptr<LoraNetDevice> loraNetDevice = DynamicCast<LoraNetDevice>(node->GetDevice(0));
         Ptr<LoraPhy> phy = loraNetDevice->GetPhy();
     }
 
@@ -325,17 +325,17 @@ main(int argc, char* argv[])
     // Install trace sources
     for (auto node = gateways.Begin(); node != gateways.End(); node++)
     {
-        (*node)->GetDevice(0)->GetObject<LoraNetDevice>()->GetPhy()->TraceConnectWithoutContext(
-            "ReceivedPacket",
-            MakeCallback(OnPacketReceptionCallback));
+        DynamicCast<LoraNetDevice>((*node)->GetDevice(0))
+            ->GetPhy()
+            ->TraceConnectWithoutContext("ReceivedPacket", MakeCallback(OnPacketReceptionCallback));
     }
 
     // Install trace sources
     for (auto node = endDevices.Begin(); node != endDevices.End(); node++)
     {
-        (*node)->GetDevice(0)->GetObject<LoraNetDevice>()->GetPhy()->TraceConnectWithoutContext(
-            "StartSending",
-            MakeCallback(OnTransmissionCallback));
+        DynamicCast<LoraNetDevice>((*node)->GetDevice(0))
+            ->GetPhy()
+            ->TraceConnectWithoutContext("StartSending", MakeCallback(OnTransmissionCallback));
     }
 
     LorawanMacHelper::SetSpreadingFactorsUp(endDevices, gateways, channel);

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -205,7 +205,7 @@ main(int argc, char* argv[])
     for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> node = *j;
-        Ptr<LoraNetDevice> loraNetDevice = node->GetDevice(0)->GetObject<LoraNetDevice>();
+        Ptr<LoraNetDevice> loraNetDevice = DynamicCast<LoraNetDevice>(node->GetDevice(0));
         Ptr<LoraPhy> phy = loraNetDevice->GetPhy();
     }
 

--- a/examples/frame-counter-update.cc
+++ b/examples/frame-counter-update.cc
@@ -211,9 +211,9 @@ main(int argc, char* argv[])
     for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> node = *j;
-        Ptr<LoraNetDevice> loraNetDevice = node->GetDevice(0)->GetObject<LoraNetDevice>();
+        Ptr<LoraNetDevice> loraNetDevice = DynamicCast<LoraNetDevice>(node->GetDevice(0));
         Ptr<LoraPhy> phy = loraNetDevice->GetPhy();
-        Ptr<EndDeviceLorawanMac> mac = loraNetDevice->GetMac()->GetObject<EndDeviceLorawanMac>();
+        Ptr<EndDeviceLorawanMac> mac = DynamicCast<EndDeviceLorawanMac>(loraNetDevice->GetMac());
         phy->TraceConnectWithoutContext("StartSending", MakeCallback(&OnPhySentPacket));
         mac->TraceConnectWithoutContext("RequiredTransmissions", MakeCallback(&OnMacPacketOutcome));
     }

--- a/examples/network-server-example.cc
+++ b/examples/network-server-example.cc
@@ -133,8 +133,8 @@ main(int argc, char* argv[])
     helper.Install(phyHelper, macHelper, endDevices);
 
     // Set message type (Default is unconfirmed)
-    Ptr<LorawanMac> edMac1 = endDevices.Get(1)->GetDevice(0)->GetObject<LoraNetDevice>()->GetMac();
-    Ptr<ClassAEndDeviceLorawanMac> edLorawanMac1 = edMac1->GetObject<ClassAEndDeviceLorawanMac>();
+    Ptr<LorawanMac> edMac1 = DynamicCast<LoraNetDevice>(endDevices.Get(1)->GetDevice(0))->GetMac();
+    Ptr<ClassAEndDeviceLorawanMac> edLorawanMac1 = DynamicCast<ClassAEndDeviceLorawanMac>(edMac1);
     edLorawanMac1->SetMType(LorawanMacHeader::CONFIRMED_DATA_UP);
 
     // Install applications in end devices

--- a/examples/parallel-reception-example.cc
+++ b/examples/parallel-reception-example.cc
@@ -147,11 +147,8 @@ main(int argc, char* argv[])
      ******************/
     for (uint32_t i = 0; i < endDevices.GetN(); i++)
     {
-        endDevices.Get(i)
-            ->GetDevice(0)
-            ->GetObject<LoraNetDevice>()
-            ->GetMac()
-            ->GetObject<EndDeviceLorawanMac>()
+        DynamicCast<EndDeviceLorawanMac>(
+            DynamicCast<LoraNetDevice>(endDevices.Get(i)->GetDevice(0))->GetMac())
             ->SetDataRate(5 - i);
     }
 

--- a/helper/lora-helper.cc
+++ b/helper/lora-helper.cc
@@ -199,10 +199,10 @@ LoraHelper::DoPrintDeviceStatus(NodeContainer endDevices,
         Ptr<MobilityModel> position = object->GetObject<MobilityModel>();
         NS_ASSERT(position);
         Ptr<NetDevice> netDevice = object->GetDevice(0);
-        Ptr<LoraNetDevice> loraNetDevice = netDevice->GetObject<LoraNetDevice>();
+        Ptr<LoraNetDevice> loraNetDevice = DynamicCast<LoraNetDevice>(netDevice);
         NS_ASSERT(loraNetDevice);
         Ptr<ClassAEndDeviceLorawanMac> mac =
-            loraNetDevice->GetMac()->GetObject<ClassAEndDeviceLorawanMac>();
+            DynamicCast<ClassAEndDeviceLorawanMac>(loraNetDevice->GetMac());
         int dr = int(mac->GetDataRate());
         double txPower = mac->GetTransmissionPower();
         Vector pos = position->GetPosition();

--- a/helper/lora-phy-helper.cc
+++ b/helper/lora-phy-helper.cc
@@ -90,7 +90,7 @@ LoraPhyHelper::Create(Ptr<Node> node, Ptr<NetDevice> device) const
 
         for (auto& f : frequencies)
         {
-            phy->GetObject<SimpleGatewayLoraPhy>()->AddFrequency(f);
+            DynamicCast<SimpleGatewayLoraPhy>(phy)->AddFrequency(f);
         }
 
         int receptionPaths = 0;
@@ -98,7 +98,7 @@ LoraPhyHelper::Create(Ptr<Node> node, Ptr<NetDevice> device) const
         // int maxReceptionPaths = 8;
         while (receptionPaths < m_maxReceptionPaths)
         {
-            phy->GetObject<SimpleGatewayLoraPhy>()->AddReceptionPath();
+            DynamicCast<SimpleGatewayLoraPhy>(phy)->AddReceptionPath();
             receptionPaths++;
         }
     }

--- a/helper/lora-radio-energy-model-helper.cc
+++ b/helper/lora-radio-energy-model-helper.cc
@@ -80,15 +80,15 @@ LoraRadioEnergyModelHelper::DoInstall(Ptr<NetDevice> device, Ptr<EnergySource> s
         NS_FATAL_ERROR("NetDevice type is not LoraNetDevice!");
     }
     Ptr<Node> node = device->GetNode();
-    Ptr<LoraRadioEnergyModel> model = m_radioEnergy.Create()->GetObject<LoraRadioEnergyModel>();
+    Ptr<LoraRadioEnergyModel> model = m_radioEnergy.Create<LoraRadioEnergyModel>();
     NS_ASSERT(model);
     // set energy source pointer
     model->SetEnergySource(source);
 
     // set energy depletion callback
     // if none is specified, make a callback to EndDeviceLoraPhy::SetSleepMode
-    Ptr<LoraNetDevice> loraDevice = device->GetObject<LoraNetDevice>();
-    Ptr<EndDeviceLoraPhy> loraPhy = loraDevice->GetPhy()->GetObject<EndDeviceLoraPhy>();
+    Ptr<LoraNetDevice> loraDevice = DynamicCast<LoraNetDevice>(device);
+    Ptr<EndDeviceLoraPhy> loraPhy = DynamicCast<EndDeviceLoraPhy>(loraDevice->GetPhy());
     // add model to device model list in energy source
     source->AppendDeviceEnergyModel(model);
     // create and register energy model phy listener

--- a/helper/lorawan-mac-helper.cc
+++ b/helper/lorawan-mac-helper.cc
@@ -71,14 +71,14 @@ LorawanMacHelper::Create(Ptr<Node> node, Ptr<NetDevice> device) const
     // If we are operating on an end device, add an address to it
     if (m_deviceType == ED_A && m_addrGen)
     {
-        mac->GetObject<ClassAEndDeviceLorawanMac>()->SetDeviceAddress(m_addrGen->NextAddress());
+        DynamicCast<ClassAEndDeviceLorawanMac>(mac)->SetDeviceAddress(m_addrGen->NextAddress());
     }
 
     // Add a basic list of channels based on the region where the device is
     // operating
     if (m_deviceType == ED_A)
     {
-        Ptr<ClassAEndDeviceLorawanMac> edMac = mac->GetObject<ClassAEndDeviceLorawanMac>();
+        Ptr<ClassAEndDeviceLorawanMac> edMac = DynamicCast<ClassAEndDeviceLorawanMac>(mac);
         switch (m_region)
         {
         case LorawanMacHelper::EU: {
@@ -101,7 +101,7 @@ LorawanMacHelper::Create(Ptr<Node> node, Ptr<NetDevice> device) const
     }
     else
     {
-        Ptr<GatewayLorawanMac> gwMac = mac->GetObject<GatewayLorawanMac>();
+        Ptr<GatewayLorawanMac> gwMac = DynamicCast<GatewayLorawanMac>(mac);
         switch (m_region)
         {
         case LorawanMacHelper::EU: {
@@ -171,7 +171,7 @@ LorawanMacHelper::ConfigureForAlohaRegion(Ptr<GatewayLorawanMac> gwMac) const
     // ReceivePath configuration //
     ///////////////////////////////
     Ptr<GatewayLoraPhy> gwPhy =
-        gwMac->GetDevice()->GetObject<LoraNetDevice>()->GetPhy()->GetObject<GatewayLoraPhy>();
+        DynamicCast<GatewayLoraPhy>(DynamicCast<LoraNetDevice>(gwMac->GetDevice())->GetPhy());
 
     ApplyCommonAlohaConfigurations(gwMac);
 
@@ -184,7 +184,7 @@ LorawanMacHelper::ConfigureForAlohaRegion(Ptr<GatewayLorawanMac> gwMac) const
         int maxReceptionPaths = 1;
         while (receptionPaths < maxReceptionPaths)
         {
-            gwPhy->GetObject<GatewayLoraPhy>()->AddReceptionPath();
+            DynamicCast<GatewayLoraPhy>(gwPhy)->AddReceptionPath();
             receptionPaths++;
         }
         gwPhy->AddFrequency(868.1);
@@ -268,7 +268,7 @@ LorawanMacHelper::ConfigureForEuRegion(Ptr<GatewayLorawanMac> gwMac) const
     // ReceivePath configuration //
     ///////////////////////////////
     Ptr<GatewayLoraPhy> gwPhy =
-        gwMac->GetDevice()->GetObject<LoraNetDevice>()->GetPhy()->GetObject<GatewayLoraPhy>();
+        DynamicCast<GatewayLoraPhy>(DynamicCast<LoraNetDevice>(gwMac->GetDevice())->GetPhy());
 
     ApplyCommonEuConfigurations(gwMac);
 
@@ -291,7 +291,7 @@ LorawanMacHelper::ConfigureForEuRegion(Ptr<GatewayLorawanMac> gwMac) const
         int maxReceptionPaths = 8;
         while (receptionPaths < maxReceptionPaths)
         {
-            gwPhy->GetObject<GatewayLoraPhy>()->AddReceptionPath();
+            DynamicCast<GatewayLoraPhy>(gwPhy)->AddReceptionPath();
             receptionPaths++;
         }
     }
@@ -382,7 +382,7 @@ LorawanMacHelper::ConfigureForSingleChannelRegion(Ptr<GatewayLorawanMac> gwMac) 
     // ReceivePath configuration //
     ///////////////////////////////
     Ptr<GatewayLoraPhy> gwPhy =
-        gwMac->GetDevice()->GetObject<LoraNetDevice>()->GetPhy()->GetObject<GatewayLoraPhy>();
+        DynamicCast<GatewayLoraPhy>(DynamicCast<LoraNetDevice>(gwMac->GetDevice())->GetPhy());
 
     ApplyCommonEuConfigurations(gwMac);
 
@@ -403,7 +403,7 @@ LorawanMacHelper::ConfigureForSingleChannelRegion(Ptr<GatewayLorawanMac> gwMac) 
         int maxReceptionPaths = 8;
         while (receptionPaths < maxReceptionPaths)
         {
-            gwPhy->GetObject<GatewayLoraPhy>()->AddReceptionPath();
+            gwPhy->AddReceptionPath();
             receptionPaths++;
         }
     }
@@ -456,10 +456,10 @@ LorawanMacHelper::SetSpreadingFactorsUp(NodeContainer endDevices,
         Ptr<MobilityModel> position = object->GetObject<MobilityModel>();
         NS_ASSERT(position);
         Ptr<NetDevice> netDevice = object->GetDevice(0);
-        Ptr<LoraNetDevice> loraNetDevice = netDevice->GetObject<LoraNetDevice>();
+        Ptr<LoraNetDevice> loraNetDevice = DynamicCast<LoraNetDevice>(netDevice);
         NS_ASSERT(loraNetDevice);
         Ptr<ClassAEndDeviceLorawanMac> mac =
-            loraNetDevice->GetMac()->GetObject<ClassAEndDeviceLorawanMac>();
+            DynamicCast<ClassAEndDeviceLorawanMac>(loraNetDevice->GetMac());
         NS_ASSERT(mac);
 
         // Try computing the distance from each gateway and find the best one
@@ -479,7 +479,7 @@ LorawanMacHelper::SetSpreadingFactorsUp(NodeContainer endDevices,
             if (currentRxPower > highestRxPower)
             {
                 bestGateway = curr;
-                bestGatewayPosition = curr->GetObject<MobilityModel>();
+                bestGatewayPosition = currPosition;
                 highestRxPower = currentRxPower;
             }
         }
@@ -488,7 +488,7 @@ LorawanMacHelper::SetSpreadingFactorsUp(NodeContainer endDevices,
         double rxPower = highestRxPower;
 
         // Get the end device sensitivity
-        Ptr<EndDeviceLoraPhy> edPhy = loraNetDevice->GetPhy()->GetObject<EndDeviceLoraPhy>();
+        Ptr<EndDeviceLoraPhy> edPhy = DynamicCast<EndDeviceLoraPhy>(loraNetDevice->GetPhy());
         const double* edSensitivity = EndDeviceLoraPhy::sensitivity;
 
         if (rxPower > *edSensitivity)
@@ -533,9 +533,9 @@ LorawanMacHelper::SetSpreadingFactorsUp(NodeContainer endDevices,
 
         // Get the Gw sensitivity
         Ptr<NetDevice> gatewayNetDevice = bestGateway->GetDevice (0);
-        Ptr<LoraNetDevice> gatewayLoraNetDevice = gatewayNetDevice->GetObject<LoraNetDevice> ();
-        Ptr<GatewayLoraPhy> gatewayPhy = gatewayLoraNetDevice->GetPhy ()->GetObject<GatewayLoraPhy>
-        (); const double *gwSensitivity = gatewayPhy->sensitivity;
+        Ptr<LoraNetDevice> gatewayLoraNetDevice = DynamicCast<LoraNetDevice>(gatewayNetDevice);
+        Ptr<GatewayLoraPhy> gatewayPhy = DynamicCast<GatewayLoraPhy>
+        (gatewayLoraNetDevice->GetPhy ()); const double *gwSensitivity = gatewayPhy->sensitivity;
 
         if(rxPower > *gwSensitivity)
           {
@@ -615,10 +615,10 @@ LorawanMacHelper::SetSpreadingFactorsGivenDistribution(NodeContainer endDevices,
         Ptr<MobilityModel> position = object->GetObject<MobilityModel>();
         NS_ASSERT(position);
         Ptr<NetDevice> netDevice = object->GetDevice(0);
-        Ptr<LoraNetDevice> loraNetDevice = netDevice->GetObject<LoraNetDevice>();
+        Ptr<LoraNetDevice> loraNetDevice = DynamicCast<LoraNetDevice>(netDevice);
         NS_ASSERT(loraNetDevice);
         Ptr<ClassAEndDeviceLorawanMac> mac =
-            loraNetDevice->GetMac()->GetObject<ClassAEndDeviceLorawanMac>();
+            DynamicCast<ClassAEndDeviceLorawanMac>(loraNetDevice->GetMac());
         NS_ASSERT(mac);
 
         double prob = uniformRV->GetValue(0, 1);

--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -114,7 +114,7 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packetToSend)
     //////////////////////////////
 
     // Switch the PHY to the channel so that it will listen here for downlink
-    m_phy->GetObject<EndDeviceLoraPhy>()->SetFrequency(txChannel->GetFrequency());
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SetFrequency(txChannel->GetFrequency());
 
     // Instruct the PHY on the right Spreading Factor to listen for during the window
     // create a SetReplyDataRate function?
@@ -123,7 +123,7 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packetToSend)
                                 << ", m_rx1DrOffset: " << unsigned(m_rx1DrOffset)
                                 << ", replyDataRate: " << unsigned(replyDataRate) << ".");
 
-    m_phy->GetObject<EndDeviceLoraPhy>()->SetSpreadingFactor(GetSfFromDataRate(replyDataRate));
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SetSpreadingFactor(GetSfFromDataRate(replyDataRate));
 }
 
 //////////////////////////
@@ -228,7 +228,7 @@ ClassAEndDeviceLorawanMac::Receive(Ptr<const Packet> packet)
         }
     }
 
-    m_phy->GetObject<EndDeviceLoraPhy>()->SwitchToSleep();
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SwitchToSleep();
 }
 
 void
@@ -237,7 +237,7 @@ ClassAEndDeviceLorawanMac::FailedReception(Ptr<const Packet> packet)
     NS_LOG_FUNCTION(this << packet);
 
     // Switch to sleep after a failed reception
-    m_phy->GetObject<EndDeviceLoraPhy>()->SwitchToSleep();
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SwitchToSleep();
 
     if (m_secondReceiveWindow.IsExpired() && m_retxParams.waitingAck)
     {
@@ -282,7 +282,7 @@ ClassAEndDeviceLorawanMac::TxFinished(Ptr<const Packet> packet)
     //                                              this);
 
     // Switch the PHY to sleep
-    m_phy->GetObject<EndDeviceLoraPhy>()->SwitchToSleep();
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SwitchToSleep();
 }
 
 void
@@ -291,7 +291,7 @@ ClassAEndDeviceLorawanMac::OpenFirstReceiveWindow()
     NS_LOG_FUNCTION_NOARGS();
 
     // Set Phy in Standby mode
-    m_phy->GetObject<EndDeviceLoraPhy>()->SwitchToStandby();
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SwitchToStandby();
 
     // Calculate the duration of a single symbol for the first receive window data rate
     double tSym = pow(2, GetSfFromDataRate(GetFirstReceiveWindowDataRate())) /
@@ -310,7 +310,7 @@ ClassAEndDeviceLorawanMac::CloseFirstReceiveWindow()
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    Ptr<EndDeviceLoraPhy> phy = m_phy->GetObject<EndDeviceLoraPhy>();
+    Ptr<EndDeviceLoraPhy> phy = DynamicCast<EndDeviceLoraPhy>(m_phy);
 
     // Check the Phy layer's state:
     // - RX -> We are receiving a preamble.
@@ -341,7 +341,7 @@ ClassAEndDeviceLorawanMac::OpenSecondReceiveWindow()
 
     // Check for receiver status: if it's locked on a packet, don't open this
     // window at all.
-    if (m_phy->GetObject<EndDeviceLoraPhy>()->GetState() == EndDeviceLoraPhy::RX)
+    if (DynamicCast<EndDeviceLoraPhy>(m_phy)->GetState() == EndDeviceLoraPhy::RX)
     {
         NS_LOG_INFO("Won't open second receive window since we are in RX mode.");
 
@@ -349,14 +349,14 @@ ClassAEndDeviceLorawanMac::OpenSecondReceiveWindow()
     }
 
     // Set Phy in Standby mode
-    m_phy->GetObject<EndDeviceLoraPhy>()->SwitchToStandby();
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SwitchToStandby();
 
     // Switch to appropriate channel and data rate
     NS_LOG_INFO("Using parameters: " << m_secondReceiveWindowFrequency << "Hz, DR"
                                      << unsigned(m_secondReceiveWindowDataRate));
 
-    m_phy->GetObject<EndDeviceLoraPhy>()->SetFrequency(m_secondReceiveWindowFrequency);
-    m_phy->GetObject<EndDeviceLoraPhy>()->SetSpreadingFactor(
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SetFrequency(m_secondReceiveWindowFrequency);
+    DynamicCast<EndDeviceLoraPhy>(m_phy)->SetSpreadingFactor(
         GetSfFromDataRate(m_secondReceiveWindowDataRate));
 
     // Calculate the duration of a single symbol for the second receive window data rate
@@ -376,7 +376,7 @@ ClassAEndDeviceLorawanMac::CloseSecondReceiveWindow()
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    Ptr<EndDeviceLoraPhy> phy = m_phy->GetObject<EndDeviceLoraPhy>();
+    Ptr<EndDeviceLoraPhy> phy = DynamicCast<EndDeviceLoraPhy>(m_phy);
 
     // NS_ASSERT (phy->m_state != EndDeviceLoraPhy::TX &&
     // phy->m_state != EndDeviceLoraPhy::SLEEP);
@@ -410,7 +410,7 @@ ClassAEndDeviceLorawanMac::CloseSecondReceiveWindow()
         }
 
         else if (m_retxParams.retxLeft == 0 &&
-                 m_phy->GetObject<EndDeviceLoraPhy>()->GetState() != EndDeviceLoraPhy::RX)
+                 DynamicCast<EndDeviceLoraPhy>(m_phy)->GetState() != EndDeviceLoraPhy::RX)
         {
             uint8_t txs = m_maxNumbTx - (m_retxParams.retxLeft);
             m_requiredTxCallback(txs, false, m_retxParams.firstAttempt, m_retxParams.packet);

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -366,7 +366,7 @@ EndDeviceLorawanMac::ParseCommands(LoraFrameHeader frameHeader)
             NS_LOG_DEBUG("Detected a LinkCheckAns command.");
 
             // Cast the command
-            Ptr<LinkCheckAns> linkCheckAns = (*it)->GetObject<LinkCheckAns>();
+            Ptr<LinkCheckAns> linkCheckAns = DynamicCast<LinkCheckAns>(*it);
 
             // Call the appropriate function to take action
             OnLinkCheckAns(linkCheckAns->GetMargin(), linkCheckAns->GetGwCnt());
@@ -377,7 +377,7 @@ EndDeviceLorawanMac::ParseCommands(LoraFrameHeader frameHeader)
             NS_LOG_DEBUG("Detected a LinkAdrReq command.");
 
             // Cast the command
-            Ptr<LinkAdrReq> linkAdrReq = (*it)->GetObject<LinkAdrReq>();
+            Ptr<LinkAdrReq> linkAdrReq = DynamicCast<LinkAdrReq>(*it);
 
             // Call the appropriate function to take action
             OnLinkAdrReq(linkAdrReq->GetDataRate(),
@@ -391,7 +391,7 @@ EndDeviceLorawanMac::ParseCommands(LoraFrameHeader frameHeader)
             NS_LOG_DEBUG("Detected a DutyCycleReq command.");
 
             // Cast the command
-            Ptr<DutyCycleReq> dutyCycleReq = (*it)->GetObject<DutyCycleReq>();
+            Ptr<DutyCycleReq> dutyCycleReq = DynamicCast<DutyCycleReq>(*it);
 
             // Call the appropriate function to take action
             OnDutyCycleReq(dutyCycleReq->GetMaximumAllowedDutyCycle());
@@ -402,7 +402,7 @@ EndDeviceLorawanMac::ParseCommands(LoraFrameHeader frameHeader)
             NS_LOG_DEBUG("Detected a RxParamSetupReq command.");
 
             // Cast the command
-            Ptr<RxParamSetupReq> rxParamSetupReq = (*it)->GetObject<RxParamSetupReq>();
+            Ptr<RxParamSetupReq> rxParamSetupReq = DynamicCast<RxParamSetupReq>(*it);
 
             // Call the appropriate function to take action
             OnRxParamSetupReq(rxParamSetupReq);
@@ -413,7 +413,7 @@ EndDeviceLorawanMac::ParseCommands(LoraFrameHeader frameHeader)
             NS_LOG_DEBUG("Detected a DevStatusReq command.");
 
             // Cast the command
-            Ptr<DevStatusReq> devStatusReq = (*it)->GetObject<DevStatusReq>();
+            Ptr<DevStatusReq> devStatusReq = DynamicCast<DevStatusReq>(*it);
 
             // Call the appropriate function to take action
             OnDevStatusReq();
@@ -424,7 +424,7 @@ EndDeviceLorawanMac::ParseCommands(LoraFrameHeader frameHeader)
             NS_LOG_DEBUG("Detected a NewChannelReq command.");
 
             // Cast the command
-            Ptr<NewChannelReq> newChannelReq = (*it)->GetObject<NewChannelReq>();
+            Ptr<NewChannelReq> newChannelReq = DynamicCast<NewChannelReq>(*it);
 
             // Call the appropriate function to take action
             OnNewChannelReq(newChannelReq->GetChannelIndex(),

--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -114,7 +114,7 @@ GatewayLorawanMac::Receive(Ptr<const Packet> packet)
 
     if (macHdr.IsUplink())
     {
-        m_device->GetObject<LoraNetDevice>()->Receive(packetCopy);
+        DynamicCast<LoraNetDevice>(m_device)->Receive(packetCopy);
 
         NS_LOG_DEBUG("Received packet: " << packet);
 

--- a/model/lora-channel.cc
+++ b/model/lora-channel.cc
@@ -95,7 +95,7 @@ LoraChannel::GetNDevices() const
 Ptr<NetDevice>
 LoraChannel::GetDevice(std::size_t i) const
 {
-    return m_phyList[i]->GetDevice()->GetObject<NetDevice>();
+    return DynamicCast<NetDevice>(m_phyList[i]->GetDevice());
 }
 
 void

--- a/model/lora-frame-header.h
+++ b/model/lora-frame-header.h
@@ -339,9 +339,9 @@ LoraFrameHeader::GetMacCommand()
     std::list<Ptr<MacCommand>>::const_iterator it;
     for (it = m_macCommands.begin(); it != m_macCommands.end(); ++it)
     {
-        if ((*it)->GetObject<T>())
+        if (DynamicCast<T>(*it))
         {
-            return (*it)->GetObject<T>();
+            return DynamicCast<T>(*it);
         }
     }
 

--- a/model/network-server.cc
+++ b/model/network-server.cc
@@ -80,7 +80,7 @@ NetworkServer::AddGateway(Ptr<Node> gateway, Ptr<NetDevice> netDevice)
     Ptr<PointToPointNetDevice> p2pNetDevice;
     for (uint32_t i = 0; i < gateway->GetNDevices(); i++)
     {
-        p2pNetDevice = gateway->GetDevice(i)->GetObject<PointToPointNetDevice>();
+        p2pNetDevice = DynamicCast<PointToPointNetDevice>(gateway->GetDevice(i));
         if (p2pNetDevice)
         {
             // We found a p2pNetDevice on the gateway
@@ -90,7 +90,7 @@ NetworkServer::AddGateway(Ptr<Node> gateway, Ptr<NetDevice> netDevice)
 
     // Get the gateway's LoRa MAC layer (assumes gateway's MAC is configured as first device)
     Ptr<GatewayLorawanMac> gwMac =
-        gateway->GetDevice(0)->GetObject<LoraNetDevice>()->GetMac()->GetObject<GatewayLorawanMac>();
+        DynamicCast<GatewayLorawanMac>(DynamicCast<LoraNetDevice>(gateway->GetDevice(0))->GetMac());
     NS_ASSERT(gwMac);
 
     // Get the Address
@@ -124,7 +124,7 @@ NetworkServer::AddNode(Ptr<Node> node)
     Ptr<LoraNetDevice> loraNetDevice;
     for (uint32_t i = 0; i < node->GetNDevices(); i++)
     {
-        loraNetDevice = node->GetDevice(i)->GetObject<LoraNetDevice>();
+        loraNetDevice = DynamicCast<LoraNetDevice>(node->GetDevice(i));
         if (loraNetDevice)
         {
             // We found a LoraNetDevice on the node
@@ -134,7 +134,7 @@ NetworkServer::AddNode(Ptr<Node> node)
 
     // Get the MAC
     Ptr<ClassAEndDeviceLorawanMac> edLorawanMac =
-        loraNetDevice->GetMac()->GetObject<ClassAEndDeviceLorawanMac>();
+        DynamicCast<ClassAEndDeviceLorawanMac>(loraNetDevice->GetMac());
 
     // Update the NetworkStatus about the existence of this node
     m_status->AddNode(edLorawanMac);

--- a/model/network-status.cc
+++ b/model/network-status.cc
@@ -59,7 +59,7 @@ NetworkStatus::AddNode(Ptr<ClassAEndDeviceLorawanMac> edMac)
     {
         // The device doesn't exist. Create new EndDeviceStatus
         Ptr<EndDeviceStatus> edStatus =
-            CreateObject<EndDeviceStatus>(edAddress, edMac->GetObject<ClassAEndDeviceLorawanMac>());
+            CreateObject<EndDeviceStatus>(edAddress, DynamicCast<ClassAEndDeviceLorawanMac>(edMac));
 
         // Add it to the map
         m_endDeviceStatuses.insert(

--- a/model/one-shot-sender.cc
+++ b/model/one-shot-sender.cc
@@ -78,7 +78,7 @@ OneShotSender::StartApplication()
     if (!m_mac)
     {
         // Assumes there's only one device
-        Ptr<LoraNetDevice> loraNetDevice = m_node->GetDevice(0)->GetObject<LoraNetDevice>();
+        Ptr<LoraNetDevice> loraNetDevice = DynamicCast<LoraNetDevice>(m_node->GetDevice(0));
 
         m_mac = loraNetDevice->GetMac();
         NS_ASSERT(m_mac);

--- a/model/periodic-sender.cc
+++ b/model/periodic-sender.cc
@@ -126,7 +126,7 @@ PeriodicSender::StartApplication()
     if (!m_mac)
     {
         // Assumes there's only one device
-        Ptr<LoraNetDevice> loraNetDevice = m_node->GetDevice(0)->GetObject<LoraNetDevice>();
+        Ptr<LoraNetDevice> loraNetDevice = DynamicCast<LoraNetDevice>(m_node->GetDevice(0));
 
         m_mac = loraNetDevice->GetMac();
         NS_ASSERT(m_mac);

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -346,7 +346,7 @@ HeaderTest::DoRun()
     // Deserialization
     frameHdr.Deserialize(serialized);
 
-    Ptr<LinkCheckAns> command = (*(frameHdr.GetCommands().begin()))->GetObject<LinkCheckAns>();
+    Ptr<LinkCheckAns> command = DynamicCast<LinkCheckAns>(*frameHdr.GetCommands().begin());
     uint8_t margin = command->GetMargin();
     uint8_t gwCnt = command->GetGwCnt();
 
@@ -388,8 +388,7 @@ HeaderTest::DoRun()
     frameHdr1.SetAsDownlink();
 
     pkt->RemoveHeader(frameHdr1);
-    Ptr<LinkCheckAns> linkCheckAns =
-        (*(frameHdr1.GetCommands().begin()))->GetObject<LinkCheckAns>();
+    Ptr<LinkCheckAns> linkCheckAns = DynamicCast<LinkCheckAns>(*frameHdr1.GetCommands().begin());
 
     NS_TEST_EXPECT_MSG_EQ((pkt->GetSize()),
                           10,
@@ -1404,8 +1403,8 @@ PhyConnectivityTest::DoRun()
 
     txParams.sf = 7;
     edPhy2->SetSpreadingFactor(7);
-    edPhy2->GetMobility()->GetObject<ConstantPositionMobilityModel>()->SetPosition(
-        Vector(2990, 0, 0));
+    DynamicCast<ConstantPositionMobilityModel>(edPhy2->GetMobility())
+        ->SetPosition(Vector(2990, 0, 0));
 
     Simulator::Schedule(Seconds(2),
                         &SimpleEndDeviceLoraPhy::Send,
@@ -1429,8 +1428,8 @@ PhyConnectivityTest::DoRun()
     // Try again using a packet with higher spreading factor
     txParams.sf = 8;
     edPhy2->SetSpreadingFactor(8);
-    edPhy2->GetMobility()->GetObject<ConstantPositionMobilityModel>()->SetPosition(
-        Vector(2990, 0, 0));
+    DynamicCast<ConstantPositionMobilityModel>(edPhy2->GetMobility())
+        ->SetPosition(Vector(2990, 0, 0));
 
     Simulator::Schedule(Seconds(2),
                         &SimpleEndDeviceLoraPhy::Send,

--- a/test/network-server-test-suite.cc
+++ b/test/network-server-test-suite.cc
@@ -183,10 +183,8 @@ DownlinkPacketTest::SendPacket(Ptr<Node> endDevice, bool requestAck)
 {
     if (requestAck)
     {
-        endDevice->GetDevice(0)
-            ->GetObject<LoraNetDevice>()
-            ->GetMac()
-            ->GetObject<EndDeviceLorawanMac>()
+        DynamicCast<EndDeviceLorawanMac>(
+            DynamicCast<LoraNetDevice>(endDevice->GetDevice(0))->GetMac())
             ->SetMType(LorawanMacHeader::CONFIRMED_DATA_UP);
     }
     endDevice->GetDevice(0)->Send(Create<Packet>(20), Address(), 0);
@@ -208,11 +206,8 @@ DownlinkPacketTest::DoRun()
     Ptr<Node> nsNode = components.nsNode;
 
     // Connect the end device's trace source for received packets
-    endDevices.Get(0)
-        ->GetDevice(0)
-        ->GetObject<LoraNetDevice>()
-        ->GetMac()
-        ->GetObject<EndDeviceLorawanMac>()
+    DynamicCast<EndDeviceLorawanMac>(
+        DynamicCast<LoraNetDevice>(endDevices.Get(0)->GetDevice(0))->GetMac())
         ->TraceConnectWithoutContext(
             "RequiredTransmissions",
             MakeCallback(&DownlinkPacketTest::ReceivedPacketAtEndDevice, this));
@@ -288,10 +283,8 @@ LinkCheckTest::LastKnownGatewayCount(int newValue, int oldValue)
 void
 LinkCheckTest::SendPacket(Ptr<Node> endDevice, bool requestAck)
 {
-    Ptr<EndDeviceLorawanMac> macLayer = endDevice->GetDevice(0)
-                                            ->GetObject<LoraNetDevice>()
-                                            ->GetMac()
-                                            ->GetObject<EndDeviceLorawanMac>();
+    Ptr<EndDeviceLorawanMac> macLayer = DynamicCast<EndDeviceLorawanMac>(
+        DynamicCast<LoraNetDevice>(endDevice->GetDevice(0))->GetMac());
 
     if (requestAck)
     {
@@ -319,11 +312,8 @@ LinkCheckTest::DoRun()
     Ptr<Node> nsNode = components.nsNode;
 
     // Connect the end device's trace source for last known gateway count
-    endDevices.Get(0)
-        ->GetDevice(0)
-        ->GetObject<LoraNetDevice>()
-        ->GetMac()
-        ->GetObject<EndDeviceLorawanMac>()
+    DynamicCast<EndDeviceLorawanMac>(
+        DynamicCast<LoraNetDevice>(endDevices.Get(0)->GetDevice(0))->GetMac())
         ->TraceConnectWithoutContext("LastKnownGatewayCount",
                                      MakeCallback(&LinkCheckTest::LastKnownGatewayCount, this));
 

--- a/test/utilities.h
+++ b/test/utilities.h
@@ -45,7 +45,7 @@ template <typename T>
 Ptr<T>
 GetMacLayerFromNode(Ptr<Node> n)
 {
-    return n->GetDevice(0)->GetObject<LoraNetDevice>()->GetMac()->GetObject<T>();
+    return DynamicCast<T>(DynamicCast<LoraNetDevice>(n->GetDevice(0))->GetMac());
 }
 
 NetworkComponents InitializeNetwork(int nDevices, int nGateways);


### PR DESCRIPTION
Refactor `GetObject` uses to explicit `DynamicCast` when actually downcasting (i.e. not getting an aggregated object).
See [Downcasting](https://www.nsnam.org/docs/release/3.43/manual/html/object-model.html#downcasting) from the Object Model section of the  ns-3 manual.

This PR is an effort to break #135 into more digestible pieces.