### PR TITLE
[MAC] Fix LogicalLoraChannelHelper Object double destruction

### DIFF
--- a/helper/lorawan-mac-helper.cc
+++ b/helper/lorawan-mac-helper.cc
@@ -200,14 +200,14 @@ LorawanMacHelper::ApplyCommonAlohaConfigurations(Ptr<LorawanMac> lorawanMac) con
     // SubBands //
     //////////////
 
-    LogicalLoraChannelHelper channelHelper;
-    channelHelper.AddSubBand(868, 868.6, 1, 14);
+    Ptr<LogicalLoraChannelHelper> channelHelper = CreateObject<LogicalLoraChannelHelper>();
+    channelHelper->AddSubBand(868, 868.6, 1, 14);
 
     //////////////////////
     // Default channels //
     //////////////////////
     Ptr<LogicalLoraChannel> lc1 = CreateObject<LogicalLoraChannel>(868.1, 0, 5);
-    channelHelper.AddChannel(lc1);
+    channelHelper->AddChannel(lc1);
 
     lorawanMac->SetLogicalLoraChannelHelper(channelHelper);
 
@@ -306,10 +306,10 @@ LorawanMacHelper::ApplyCommonEuConfigurations(Ptr<LorawanMac> lorawanMac) const
     // SubBands //
     //////////////
 
-    LogicalLoraChannelHelper channelHelper;
-    channelHelper.AddSubBand(868, 868.6, 0.01, 14);
-    channelHelper.AddSubBand(868.7, 869.2, 0.001, 14);
-    channelHelper.AddSubBand(869.4, 869.65, 0.1, 27);
+    Ptr<LogicalLoraChannelHelper> channelHelper = CreateObject<LogicalLoraChannelHelper>();
+    channelHelper->AddSubBand(868, 868.6, 0.01, 14);
+    channelHelper->AddSubBand(868.7, 869.2, 0.001, 14);
+    channelHelper->AddSubBand(869.4, 869.65, 0.1, 27);
 
     //////////////////////
     // Default channels //
@@ -317,9 +317,9 @@ LorawanMacHelper::ApplyCommonEuConfigurations(Ptr<LorawanMac> lorawanMac) const
     Ptr<LogicalLoraChannel> lc1 = CreateObject<LogicalLoraChannel>(868.1, 0, 5);
     Ptr<LogicalLoraChannel> lc2 = CreateObject<LogicalLoraChannel>(868.3, 0, 5);
     Ptr<LogicalLoraChannel> lc3 = CreateObject<LogicalLoraChannel>(868.5, 0, 5);
-    channelHelper.AddChannel(lc1);
-    channelHelper.AddChannel(lc2);
-    channelHelper.AddChannel(lc3);
+    channelHelper->AddChannel(lc1);
+    channelHelper->AddChannel(lc2);
+    channelHelper->AddChannel(lc3);
 
     lorawanMac->SetLogicalLoraChannelHelper(channelHelper);
 
@@ -418,16 +418,16 @@ LorawanMacHelper::ApplyCommonSingleChannelConfigurations(Ptr<LorawanMac> lorawan
     // SubBands //
     //////////////
 
-    LogicalLoraChannelHelper channelHelper;
-    channelHelper.AddSubBand(868, 868.6, 0.01, 14);
-    channelHelper.AddSubBand(868.7, 869.2, 0.001, 14);
-    channelHelper.AddSubBand(869.4, 869.65, 0.1, 27);
+    Ptr<LogicalLoraChannelHelper> channelHelper = CreateObject<LogicalLoraChannelHelper>();
+    channelHelper->AddSubBand(868, 868.6, 0.01, 14);
+    channelHelper->AddSubBand(868.7, 869.2, 0.001, 14);
+    channelHelper->AddSubBand(869.4, 869.65, 0.1, 27);
 
     //////////////////////
     // Default channels //
     //////////////////////
     Ptr<LogicalLoraChannel> lc1 = CreateObject<LogicalLoraChannel>(868.1, 0, 5);
-    channelHelper.AddChannel(lc1);
+    channelHelper->AddChannel(lc1);
 
     lorawanMac->SetLogicalLoraChannelHelper(channelHelper);
 

--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -107,7 +107,7 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packetToSend)
     Time duration = LoraPhy::GetOnAirTime(packetToSend, params);
 
     // Register the sent packet into the DutyCycleHelper
-    m_channelHelper.AddEvent(duration, txChannel);
+    m_channelHelper->AddEvent(duration, txChannel);
 
     //////////////////////////////
     // Prepare for the downlink //

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -175,7 +175,7 @@ EndDeviceLorawanMac::Send(Ptr<Packet> packet)
     // retransmissions
     {
         // Make sure we can transmit at the current power on this channel
-        NS_ASSERT_MSG(m_txPower <= m_channelHelper.GetTxPowerForChannel(txChannel),
+        NS_ASSERT_MSG(m_txPower <= m_channelHelper->GetTxPowerForChannel(txChannel),
                       " The selected power is too high to be supported by this channel.");
         DoSend(packet);
     }
@@ -513,7 +513,7 @@ EndDeviceLorawanMac::GetNextTransmissionDelay()
     // Pick a random channel to transmit on
     std::vector<Ptr<LogicalLoraChannel>> logicalChannels;
     logicalChannels =
-        m_channelHelper.GetEnabledChannelList(); // Use a separate list to do the shuffle
+        m_channelHelper->GetEnabledChannelList(); // Use a separate list to do the shuffle
     // logicalChannels = Shuffle (logicalChannels);
 
     Time waitingTime = Time::Max();
@@ -526,7 +526,7 @@ EndDeviceLorawanMac::GetNextTransmissionDelay()
         Ptr<LogicalLoraChannel> logicalChannel = *it;
         double frequency = logicalChannel->GetFrequency();
 
-        waitingTime = std::min(waitingTime, m_channelHelper.GetWaitingTime(logicalChannel));
+        waitingTime = std::min(waitingTime, m_channelHelper->GetWaitingTime(logicalChannel));
 
         NS_LOG_DEBUG("Waiting time before the next transmission in channel with frequency "
                      << frequency << " is = " << waitingTime.GetSeconds() << ".");
@@ -545,7 +545,7 @@ EndDeviceLorawanMac::GetChannelForTx()
     // Pick a random channel to transmit on
     std::vector<Ptr<LogicalLoraChannel>> logicalChannels;
     logicalChannels =
-        m_channelHelper.GetEnabledChannelList(); // Use a separate list to do the shuffle
+        m_channelHelper->GetEnabledChannelList(); // Use a separate list to do the shuffle
     logicalChannels = Shuffle(logicalChannels);
 
     // Try every channel
@@ -559,7 +559,7 @@ EndDeviceLorawanMac::GetChannelForTx()
         NS_LOG_DEBUG("Frequency of the current channel: " << frequency);
 
         // Verify that we can send the packet
-        Time waitingTime = m_channelHelper.GetWaitingTime(logicalChannel);
+        Time waitingTime = m_channelHelper->GetWaitingTime(logicalChannel);
 
         NS_LOG_DEBUG("Waiting time for current channel = " << waitingTime.GetSeconds());
 
@@ -696,7 +696,7 @@ EndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
     // Check the channel mask
     /////////////////////////
     // Check whether all specified channels exist on this device
-    auto channelList = m_channelHelper.GetChannelList();
+    auto channelList = m_channelHelper->GetChannelList();
     int channelListSize = channelList.size();
 
     for (auto it = enabledChannels.begin(); it != enabledChannels.end(); it++)
@@ -765,17 +765,17 @@ EndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
     if (channelMaskOk && dataRateOk && txPowerOk)
     {
         // Cycle over all channels in the list
-        for (uint32_t i = 0; i < m_channelHelper.GetChannelList().size(); i++)
+        for (uint32_t i = 0; i < m_channelHelper->GetChannelList().size(); i++)
         {
             if (std::find(enabledChannels.begin(), enabledChannels.end(), i) !=
                 enabledChannels.end())
             {
-                m_channelHelper.GetChannelList().at(i)->SetEnabledForUplink();
+                m_channelHelper->GetChannelList().at(i)->SetEnabledForUplink();
                 NS_LOG_DEBUG("Channel " << i << " enabled");
             }
             else
             {
-                m_channelHelper.GetChannelList().at(i)->DisableForUplink();
+                m_channelHelper->GetChannelList().at(i)->DisableForUplink();
                 NS_LOG_DEBUG("Channel " << i << " disabled");
             }
         }
@@ -860,7 +860,7 @@ EndDeviceLorawanMac::AddLogicalChannel(double frequency)
 {
     NS_LOG_FUNCTION(this << frequency);
 
-    m_channelHelper.AddChannel(frequency);
+    m_channelHelper->AddChannel(frequency);
 }
 
 void
@@ -868,7 +868,7 @@ EndDeviceLorawanMac::AddLogicalChannel(Ptr<LogicalLoraChannel> logicalChannel)
 {
     NS_LOG_FUNCTION(this << logicalChannel);
 
-    m_channelHelper.AddChannel(logicalChannel);
+    m_channelHelper->AddChannel(logicalChannel);
 }
 
 void
@@ -880,7 +880,7 @@ EndDeviceLorawanMac::SetLogicalChannel(uint8_t chIndex,
     NS_LOG_FUNCTION(this << unsigned(chIndex) << frequency << unsigned(minDataRate)
                          << unsigned(maxDataRate));
 
-    m_channelHelper.SetChannel(
+    m_channelHelper->SetChannel(
         chIndex,
         CreateObject<LogicalLoraChannel>(frequency, minDataRate, maxDataRate));
 }
@@ -893,7 +893,7 @@ EndDeviceLorawanMac::AddSubBand(double startFrequency,
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    m_channelHelper.AddSubBand(startFrequency, endFrequency, dutyCycle, maxTxPowerDbm);
+    m_channelHelper->AddSubBand(startFrequency, endFrequency, dutyCycle, maxTxPowerDbm);
 }
 
 double

--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -60,7 +60,7 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     packet->AddPacketTag(tag);
 
     // Make sure we can transmit this packet
-    if (m_channelHelper.GetWaitingTime(CreateObject<LogicalLoraChannel>(frequency)) > Time(0))
+    if (m_channelHelper->GetWaitingTime(CreateObject<LogicalLoraChannel>(frequency)) > Time(0))
     {
         // We cannot send now!
         NS_LOG_WARN("Trying to send a packet but Duty Cycle won't allow it. Aborting.");
@@ -83,10 +83,10 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
 
     // Find the channel with the desired frequency
     double sendingPower =
-        m_channelHelper.GetTxPowerForChannel(CreateObject<LogicalLoraChannel>(frequency));
+        m_channelHelper->GetTxPowerForChannel(CreateObject<LogicalLoraChannel>(frequency));
 
     // Add the event to the channelHelper to keep track of duty cycle
-    m_channelHelper.AddEvent(duration, CreateObject<LogicalLoraChannel>(frequency));
+    m_channelHelper->AddEvent(duration, CreateObject<LogicalLoraChannel>(frequency));
 
     // Send the packet to the PHY layer to send it on the channel
     m_phy->Send(packet, params, frequency, sendingPower);
@@ -143,7 +143,7 @@ GatewayLorawanMac::GetWaitingTime(double frequency)
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    return m_channelHelper.GetWaitingTime(CreateObject<LogicalLoraChannel>(frequency));
+    return m_channelHelper->GetWaitingTime(CreateObject<LogicalLoraChannel>(frequency));
 }
 } // namespace lorawan
 } // namespace ns3

--- a/model/lorawan-mac.cc
+++ b/model/lorawan-mac.cc
@@ -84,14 +84,14 @@ LorawanMac::SetPhy(Ptr<LoraPhy> phy)
     m_phy->SetTxFinishedCallback(MakeCallback(&LorawanMac::TxFinished, this));
 }
 
-LogicalLoraChannelHelper
+Ptr<LogicalLoraChannelHelper>
 LorawanMac::GetLogicalLoraChannelHelper()
 {
     return m_channelHelper;
 }
 
 void
-LorawanMac::SetLogicalLoraChannelHelper(LogicalLoraChannelHelper helper)
+LorawanMac::SetLogicalLoraChannelHelper(Ptr<LogicalLoraChannelHelper> helper)
 {
     m_channelHelper = helper;
 }

--- a/model/lorawan-mac.h
+++ b/model/lorawan-mac.h
@@ -112,16 +112,16 @@ class LorawanMac : public Object
     /**
      * Get the logical lora channel helper associated with this MAC.
      *
-     * \return The instance of LogicalLoraChannelHelper that this MAC is using.
+     * \return A Ptr to the instance of LogicalLoraChannelHelper that this MAC is using.
      */
-    LogicalLoraChannelHelper GetLogicalLoraChannelHelper();
+    Ptr<LogicalLoraChannelHelper> GetLogicalLoraChannelHelper();
 
     /**
      * Set the LogicalLoraChannelHelper this MAC instance will use.
      *
-     * \param helper The instance of the helper to use.
+     * \param helper A Ptr to the instance of the helper to use.
      */
-    void SetLogicalLoraChannelHelper(LogicalLoraChannelHelper helper);
+    void SetLogicalLoraChannelHelper(Ptr<LogicalLoraChannelHelper> helper);
 
     /**
      * Get the spreading factor corresponding to a data rate, based on this MAC's region.
@@ -243,7 +243,7 @@ class LorawanMac : public Object
     /**
      * The LogicalLoraChannelHelper instance that is assigned to this MAC.
      */
-    LogicalLoraChannelHelper m_channelHelper;
+    Ptr<LogicalLoraChannelHelper> m_channelHelper;
 
     /**
      * A vector holding the spreading factor each data rate corresponds to.


### PR DESCRIPTION
Bug explanation: `SetLogicalLoraChannelHelper()` assigned a plain `LogicalLoraChannelHelper` `Object` (i.e., not a `Ptr`) to `LorawanMac`'s member. Objects do not have a dedicated assignment operator implementation so their members are copied without modifications. Objects internally store a pointer to a buffer of aggregated objects. When the copy-assigned function parameter Object goes out of scope, its destructor is called, clearing the buffer of aggregated objects stored inside. The same buffer address was also stored in the `LorawanMac`'s member by the copy assignment. At `LorawanMac` destruction time, this causes a second attempt at clearing the buffer, accessing already unallocated memory.

Note: The examples do not end up in a segmentation fault because currently ref counting pointers are not correctly released at the end of the simulation, effectively causing a memory leak. In the future we must implement DoDispose.

Note2: Found this while trying to implement MAC layer tests for coverage of #179.