### PR TITLE
Improve names and apply minor refactoring

### DIFF
--- a/examples/adr-example.cc
+++ b/examples/adr-example.cc
@@ -73,7 +73,7 @@ main(int argc, char* argv[])
     double mobileNodeProbability = 0;
     double sideLengthMeters = 10000;
     int gatewayDistanceMeters = 5000;
-    double maxRandomLossDB = 10;
+    double maxRandomLossDb = 10;
     double minSpeedMetersPerSecond = 2;
     double maxSpeedMetersPerSecond = 16;
     std::string adrType = "ns3::AdrComponent";
@@ -98,7 +98,7 @@ main(int argc, char* argv[])
                  sideLengthMeters);
     cmd.AddValue("maxRandomLoss",
                  "Maximum amount (dB) of the random loss component",
-                 maxRandomLossDB);
+                 maxRandomLossDb);
     cmd.AddValue("gatewayDistance", "Distance (m) between gateways", gatewayDistanceMeters);
     cmd.AddValue("initializeSF", "Whether to initialize the SFs", initializeSF);
     cmd.AddValue("MinSpeed", "Minimum speed (m/s) for mobile devices", minSpeedMetersPerSecond);
@@ -143,7 +143,7 @@ main(int argc, char* argv[])
 
     Ptr<UniformRandomVariable> x = CreateObject<UniformRandomVariable>();
     x->SetAttribute("Min", DoubleValue(0.0));
-    x->SetAttribute("Max", DoubleValue(maxRandomLossDB));
+    x->SetAttribute("Max", DoubleValue(maxRandomLossDb));
 
     Ptr<RandomPropagationLossModel> randomLoss = CreateObject<RandomPropagationLossModel>();
     randomLoss->SetAttribute("Variable", PointerValue(x));

--- a/examples/aloha-throughput.cc
+++ b/examples/aloha-throughput.cc
@@ -258,7 +258,7 @@ main(int argc, char* argv[])
     appHelper.SetPacketSize(packetSize);
     ApplicationContainer appContainer = appHelper.Install(endDevices);
 
-    appContainer.Start(Seconds(0));
+    appContainer.Start(Time(0));
     appContainer.Stop(appStopTime);
 
     std::ofstream outputFile;

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -305,7 +305,7 @@ main(int argc, char* argv[])
                                                           DoubleValue(10));
     ApplicationContainer appContainer = appHelper.Install(endDevices);
 
-    appContainer.Start(Seconds(0));
+    appContainer.Start(Time(0));
     appContainer.Stop(appStopTime);
 
     /**************************
@@ -353,7 +353,7 @@ main(int argc, char* argv[])
     NS_LOG_INFO("Computing performance metrics...");
 
     LoraPacketTracker& tracker = helper.GetPacketTracker();
-    std::cout << tracker.CountMacPacketsGlobally(Seconds(0), appStopTime + Hours(1)) << std::endl;
+    std::cout << tracker.CountMacPacketsGlobally(Time(0), appStopTime + Hours(1)) << std::endl;
 
     return 0;
 }

--- a/examples/frame-counter-update.cc
+++ b/examples/frame-counter-update.cc
@@ -239,14 +239,14 @@ main(int argc, char* argv[])
 
     Time appStopTime = Seconds(simulationTimeSeconds);
     OneShotSenderHelper appHelper = OneShotSenderHelper();
-    appHelper.SetSendTime(Seconds(0));
+    appHelper.SetSendTime(Time(0));
     ApplicationContainer appContainer = appHelper.Install(endDevices);
     appHelper.SetSendTime(Seconds(100));
     appContainer.Add(appHelper.Install(endDevices));
     appHelper.SetSendTime(Seconds(200));
     appContainer.Add(appHelper.Install(endDevices));
 
-    appContainer.Start(Seconds(0));
+    appContainer.Start(Time(0));
     appContainer.Stop(appStopTime);
 
     Simulator::Schedule(Seconds(110), &ChangeEndDevicePosition, endDevices.Get(0), true);
@@ -298,7 +298,7 @@ main(int argc, char* argv[])
 
     LoraPacketTracker& tracker = helper.GetPacketTracker();
     NS_LOG_INFO("Printing total sent MAC-layer packets and successful MAC-layer packets");
-    std::cout << tracker.CountMacPacketsGlobally(Seconds(0), appStopTime + Hours(1)) << std::endl;
+    std::cout << tracker.CountMacPacketsGlobally(Time(0), appStopTime + Hours(1)) << std::endl;
 
     return 0;
 }

--- a/helper/lora-helper.cc
+++ b/helper/lora-helper.cc
@@ -47,7 +47,7 @@ LoraHelper::Install(const LoraPhyHelper& phyHelper,
         Ptr<LoraNetDevice> device = CreateObject<LoraNetDevice>();
 
         // Create the PHY
-        Ptr<LoraPhy> phy = phyHelper.Create(node, device);
+        Ptr<LoraPhy> phy = phyHelper.Install(node, device);
         NS_ASSERT(phy);
         device->SetPhy(phy);
         NS_LOG_DEBUG("Done creating the PHY");
@@ -85,7 +85,7 @@ LoraHelper::Install(const LoraPhyHelper& phyHelper,
         }
 
         // Create the MAC
-        Ptr<LorawanMac> mac = macHelper.Create(node, device);
+        Ptr<LorawanMac> mac = macHelper.Install(node, device);
         NS_ASSERT(mac);
         mac->SetPhy(phy);
         NS_LOG_DEBUG("Done creating the MAC");

--- a/helper/lora-helper.cc
+++ b/helper/lora-helper.cc
@@ -20,8 +20,8 @@ namespace lorawan
 NS_LOG_COMPONENT_DEFINE("LoraHelper");
 
 LoraHelper::LoraHelper()
-    : m_lastPhyPerformanceUpdate(Seconds(0)),
-      m_lastGlobalPerformanceUpdate(Seconds(0))
+    : m_lastPhyPerformanceUpdate(Time(0)),
+      m_lastGlobalPerformanceUpdate(Time(0))
 {
 }
 
@@ -151,7 +151,7 @@ void
 LoraHelper::EnableSimulationTimePrinting(Time interval)
 {
     m_oldtime = std::time(nullptr);
-    Simulator::Schedule(Seconds(0), &LoraHelper::DoPrintSimulationTime, this, interval);
+    Simulator::Schedule(Time(0), &LoraHelper::DoPrintSimulationTime, this, interval);
 }
 
 void
@@ -181,7 +181,7 @@ LoraHelper::DoPrintDeviceStatus(NodeContainer endDevices,
 {
     const char* c = filename.c_str();
     std::ofstream outputFile;
-    if (Simulator::Now() == Seconds(0))
+    if (Now().IsZero())
     {
         // Delete contents of the file as it is opened
         outputFile.open(c, std::ofstream::out | std::ofstream::trunc);
@@ -192,7 +192,7 @@ LoraHelper::DoPrintDeviceStatus(NodeContainer endDevices,
         outputFile.open(c, std::ofstream::out | std::ofstream::app);
     }
 
-    Time currentTime = Simulator::Now();
+    Time currentTime = Now();
     for (auto j = endDevices.Begin(); j != endDevices.End(); ++j)
     {
         Ptr<Node> object = *j;
@@ -206,7 +206,7 @@ LoraHelper::DoPrintDeviceStatus(NodeContainer endDevices,
         int dr = int(mac->GetDataRate());
         double txPower = mac->GetTransmissionPowerDbm();
         Vector pos = position->GetPosition();
-        outputFile << currentTime.GetSeconds() << " " << object->GetId() << " " << pos.x << " "
+        outputFile << currentTime.As(Time::S) << " " << object->GetId() << " " << pos.x << " "
                    << pos.y << " " << dr << " " << unsigned(txPower) << std::endl;
     }
     // for (NodeContainer::Iterator j = gateways.Begin (); j != gateways.End (); ++j)
@@ -245,7 +245,7 @@ LoraHelper::DoPrintPhyPerformance(NodeContainer gateways, std::string filename)
 
     const char* c = filename.c_str();
     std::ofstream outputFile;
-    if (Simulator::Now() == Seconds(0))
+    if (Now().IsZero())
     {
         // Delete contents of the file as it is opened
         outputFile.open(c, std::ofstream::out | std::ofstream::trunc);
@@ -259,14 +259,14 @@ LoraHelper::DoPrintPhyPerformance(NodeContainer gateways, std::string filename)
     for (auto it = gateways.Begin(); it != gateways.End(); ++it)
     {
         int systemId = (*it)->GetId();
-        outputFile << Simulator::Now().GetSeconds() << " " << std::to_string(systemId) << " "
+        outputFile << Now().As(Time::S) << " " << std::to_string(systemId) << " "
                    << m_packetTracker->PrintPhyPacketsPerGw(m_lastPhyPerformanceUpdate,
-                                                            Simulator::Now(),
+                                                            Now(),
                                                             systemId)
                    << std::endl;
     }
 
-    m_lastPhyPerformanceUpdate = Simulator::Now();
+    m_lastPhyPerformanceUpdate = Now();
 
     outputFile.close();
 }
@@ -292,7 +292,7 @@ LoraHelper::DoPrintGlobalPerformance(std::string filename)
 
     const char* c = filename.c_str();
     std::ofstream outputFile;
-    if (Simulator::Now() == Seconds(0))
+    if (Now().IsZero())
     {
         // Delete contents of the file as it is opened
         outputFile.open(c, std::ofstream::out | std::ofstream::trunc);
@@ -303,12 +303,11 @@ LoraHelper::DoPrintGlobalPerformance(std::string filename)
         outputFile.open(c, std::ofstream::out | std::ofstream::app);
     }
 
-    outputFile << Simulator::Now().GetSeconds() << " "
-               << m_packetTracker->CountMacPacketsGlobally(m_lastGlobalPerformanceUpdate,
-                                                           Simulator::Now())
+    outputFile << Now().As(Time::S) << " "
+               << m_packetTracker->CountMacPacketsGlobally(m_lastGlobalPerformanceUpdate, Now())
                << std::endl;
 
-    m_lastGlobalPerformanceUpdate = Simulator::Now();
+    m_lastGlobalPerformanceUpdate = Now();
 
     outputFile.close();
 }
@@ -316,8 +315,8 @@ LoraHelper::DoPrintGlobalPerformance(std::string filename)
 void
 LoraHelper::DoPrintSimulationTime(Time interval)
 {
-    // NS_LOG_INFO ("Time: " << Simulator::Now().GetHours());
-    std::cout << "Simulated time: " << Simulator::Now().GetHours() << " hours" << std::endl;
+    // NS_LOG_INFO ("Time: " << Now().As(Time::H));
+    std::cout << "Simulated time: " << Now().As(Time::H) << std::endl;
     std::cout << "Real time from last call: " << std::time(nullptr) - m_oldtime << " seconds"
               << std::endl;
     m_oldtime = std::time(nullptr);

--- a/helper/lora-helper.cc
+++ b/helper/lora-helper.cc
@@ -204,7 +204,7 @@ LoraHelper::DoPrintDeviceStatus(NodeContainer endDevices,
         Ptr<ClassAEndDeviceLorawanMac> mac =
             DynamicCast<ClassAEndDeviceLorawanMac>(loraNetDevice->GetMac());
         int dr = int(mac->GetDataRate());
-        double txPower = mac->GetTransmissionPower();
+        double txPower = mac->GetTransmissionPowerDbm();
         Vector pos = position->GetPosition();
         outputFile << currentTime.GetSeconds() << " " << object->GetId() << " " << pos.x << " "
                    << pos.y << " " << dr << " " << unsigned(txPower) << std::endl;

--- a/helper/lora-packet-tracker.cc
+++ b/helper/lora-packet-tracker.cc
@@ -44,7 +44,7 @@ LoraPacketTracker::MacTransmissionCallback(Ptr<const Packet> packet)
 
         MacPacketStatus status;
         status.packet = packet;
-        status.sendTime = Simulator::Now();
+        status.sendTime = Now();
         status.senderId = Simulator::GetContext();
         status.receivedTime = Time::Max();
 
@@ -60,11 +60,11 @@ LoraPacketTracker::RequiredTransmissionsCallback(uint8_t reqTx,
 {
     NS_LOG_INFO("Finished retransmission attempts for a packet");
     NS_LOG_DEBUG("Packet: " << packet << "ReqTx " << unsigned(reqTx) << ", succ: " << success
-                            << ", firstAttempt: " << firstAttempt.GetSeconds());
+                            << ", firstAttempt: " << firstAttempt.As(Time::S));
 
     RetransmissionStatus entry;
     entry.firstAttempt = firstAttempt;
-    entry.finishTime = Simulator::Now();
+    entry.finishTime = Now();
     entry.reTxAttempts = reqTx;
     entry.successful = success;
 
@@ -84,7 +84,7 @@ LoraPacketTracker::MacGwReceptionCallback(Ptr<const Packet> packet)
         if (it != m_macPacketTracker.end())
         {
             (*it).second.receptionTimes.insert(
-                std::pair<int, Time>(Simulator::GetContext(), Simulator::Now()));
+                std::pair<int, Time>(Simulator::GetContext(), Now()));
         }
         else
         {
@@ -106,7 +106,7 @@ LoraPacketTracker::TransmissionCallback(Ptr<const Packet> packet, uint32_t edId)
         // Create a packetStatus
         PacketStatus status;
         status.packet = packet;
-        status.sendTime = Simulator::Now();
+        status.sendTime = Now();
         status.senderId = edId;
 
         m_packetTracker.insert(std::pair<Ptr<const Packet>, PacketStatus>(packet, status));

--- a/helper/lora-phy-helper.cc
+++ b/helper/lora-phy-helper.cc
@@ -60,7 +60,7 @@ LoraPhyHelper::Set(std::string name, const AttributeValue& v)
 }
 
 Ptr<LoraPhy>
-LoraPhyHelper::Create(Ptr<Node> node, Ptr<NetDevice> device) const
+LoraPhyHelper::Install(Ptr<Node> node, Ptr<NetDevice> device) const
 {
     NS_LOG_FUNCTION(this << node->GetId() << device);
 

--- a/helper/lora-phy-helper.h
+++ b/helper/lora-phy-helper.h
@@ -80,7 +80,7 @@ class LoraPhyHelper
      * @param device The device within which this PHY will be created.
      * @return A newly-created PHY object.
      */
-    Ptr<LoraPhy> Create(Ptr<Node> node, Ptr<NetDevice> device) const;
+    Ptr<LoraPhy> Install(Ptr<Node> node, Ptr<NetDevice> device) const;
 
     /**
      * Set the maximum number of gateway receive paths.

--- a/helper/lorawan-mac-helper.cc
+++ b/helper/lorawan-mac-helper.cc
@@ -63,7 +63,7 @@ LorawanMacHelper::SetRegion(enum LorawanMacHelper::Regions region)
 }
 
 Ptr<LorawanMac>
-LorawanMacHelper::Create(Ptr<Node> node, Ptr<NetDevice> device) const
+LorawanMacHelper::Install(Ptr<Node> node, Ptr<NetDevice> device) const
 {
     Ptr<LorawanMac> mac = m_mac.Create<LorawanMac>();
     mac->SetDevice(device);
@@ -200,13 +200,13 @@ LorawanMacHelper::ApplyCommonAlohaConfigurations(Ptr<LorawanMac> lorawanMac) con
     // SubBands //
     //////////////
 
-    auto channelHelper = ns3::Create<LogicalLoraChannelHelper>(1);
-    channelHelper->AddSubBand(ns3::Create<SubBand>(868, 868.6, 1, 14));
+    auto channelHelper = Create<LogicalLoraChannelHelper>(1);
+    channelHelper->AddSubBand(Create<SubBand>(868, 868.6, 1, 14));
 
     //////////////////////
     // Default channels //
     //////////////////////
-    Ptr<LogicalLoraChannel> lc1 = ns3::Create<LogicalLoraChannel>(868.1, 0, 5);
+    Ptr<LogicalLoraChannel> lc1 = Create<LogicalLoraChannel>(868.1, 0, 5);
     channelHelper->SetChannel(0, lc1);
 
     lorawanMac->SetLogicalLoraChannelHelper(channelHelper);
@@ -306,20 +306,20 @@ LorawanMacHelper::ApplyCommonEuConfigurations(Ptr<LorawanMac> lorawanMac) const
     // SubBands //
     //////////////
 
-    auto channelHelper = ns3::Create<LogicalLoraChannelHelper>(16);
-    channelHelper->AddSubBand(ns3::Create<SubBand>(863, 865, 0.001, 14));
-    channelHelper->AddSubBand(ns3::Create<SubBand>(865, 868, 0.01, 14));
-    channelHelper->AddSubBand(ns3::Create<SubBand>(868, 868.6, 0.01, 14));
-    channelHelper->AddSubBand(ns3::Create<SubBand>(868.7, 869.2, 0.001, 14));
-    channelHelper->AddSubBand(ns3::Create<SubBand>(869.4, 869.65, 0.1, 27));
-    channelHelper->AddSubBand(ns3::Create<SubBand>(869.7, 870, 0.01, 14));
+    auto channelHelper = Create<LogicalLoraChannelHelper>(16);
+    channelHelper->AddSubBand(Create<SubBand>(863, 865, 0.001, 14));
+    channelHelper->AddSubBand(Create<SubBand>(865, 868, 0.01, 14));
+    channelHelper->AddSubBand(Create<SubBand>(868, 868.6, 0.01, 14));
+    channelHelper->AddSubBand(Create<SubBand>(868.7, 869.2, 0.001, 14));
+    channelHelper->AddSubBand(Create<SubBand>(869.4, 869.65, 0.1, 27));
+    channelHelper->AddSubBand(Create<SubBand>(869.7, 870, 0.01, 14));
 
     //////////////////////
     // Default channels //
     //////////////////////
-    Ptr<LogicalLoraChannel> lc1 = ns3::Create<LogicalLoraChannel>(868.1, 0, 5);
-    Ptr<LogicalLoraChannel> lc2 = ns3::Create<LogicalLoraChannel>(868.3, 0, 5);
-    Ptr<LogicalLoraChannel> lc3 = ns3::Create<LogicalLoraChannel>(868.5, 0, 5);
+    Ptr<LogicalLoraChannel> lc1 = Create<LogicalLoraChannel>(868.1, 0, 5);
+    Ptr<LogicalLoraChannel> lc2 = Create<LogicalLoraChannel>(868.3, 0, 5);
+    Ptr<LogicalLoraChannel> lc3 = Create<LogicalLoraChannel>(868.5, 0, 5);
     channelHelper->SetChannel(0, lc1);
     channelHelper->SetChannel(1, lc2);
     channelHelper->SetChannel(2, lc3);
@@ -421,13 +421,13 @@ LorawanMacHelper::ApplyCommonSingleChannelConfigurations(Ptr<LorawanMac> lorawan
     // SubBands //
     //////////////
 
-    auto channelHelper = ns3::Create<LogicalLoraChannelHelper>(1);
-    channelHelper->AddSubBand(ns3::Create<SubBand>(868, 868.6, 0.01, 14));
+    auto channelHelper = Create<LogicalLoraChannelHelper>(1);
+    channelHelper->AddSubBand(Create<SubBand>(868, 868.6, 0.01, 14));
 
     //////////////////////
     // Default channels //
     //////////////////////
-    Ptr<LogicalLoraChannel> lc1 = ns3::Create<LogicalLoraChannel>(868.1, 0, 5);
+    Ptr<LogicalLoraChannel> lc1 = Create<LogicalLoraChannel>(868.1, 0, 5);
     channelHelper->SetChannel(0, lc1);
 
     lorawanMac->SetLogicalLoraChannelHelper(channelHelper);

--- a/helper/lorawan-mac-helper.h
+++ b/helper/lorawan-mac-helper.h
@@ -97,7 +97,7 @@ class LorawanMacHelper
      * @param device The device within which this MAC will be created.
      * @return A newly-created LorawanMac object.
      */
-    Ptr<LorawanMac> Create(Ptr<Node> node, Ptr<NetDevice> device) const;
+    Ptr<LorawanMac> Install(Ptr<Node> node, Ptr<NetDevice> device) const;
 
     /**
      * Initialize the end devices' data rate parameter.

--- a/helper/periodic-sender-helper.cc
+++ b/helper/periodic-sender-helper.cc
@@ -77,7 +77,7 @@ PeriodicSenderHelper::InstallPriv(Ptr<Node> node) const
     Ptr<PeriodicSender> app = m_factory.Create<PeriodicSender>();
 
     Time interval;
-    if (m_period == Seconds(0))
+    if (m_period.IsZero())
     {
         double intervalProb = m_intervalProb->GetValue();
         NS_LOG_DEBUG("IntervalProb = " << intervalProb);
@@ -106,7 +106,7 @@ PeriodicSenderHelper::InstallPriv(Ptr<Node> node) const
     }
 
     app->SetInterval(interval);
-    NS_LOG_DEBUG("Created an application with interval = " << interval.GetHours() << " hours");
+    NS_LOG_DEBUG("Created an application with interval = " << interval.As(Time::H));
 
     app->SetInitialDelay(Seconds(m_initialDelay->GetValue(0, interval.GetSeconds())));
     app->SetPacketSize(m_pktSize);

--- a/model/adr-component.cc
+++ b/model/adr-component.cc
@@ -110,22 +110,22 @@ AdrComponent::BeforeSendingReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus>
             uint8_t spreadingFactor = status->GetFirstReceiveWindowSpreadingFactor();
 
             // Get the device transmission power (dBm)
-            uint8_t transmissionPower = status->GetMac()->GetTransmissionPower();
+            double transmissionPowerDbm = status->GetMac()->GetTransmissionPowerDbm();
 
             // New parameters for the end-device
             uint8_t newDataRate;
-            uint8_t newTxPower;
+            double newTxPowerDbm;
 
             // Adaptive Data Rate (ADR) Algorithm
-            AdrImplementation(&newDataRate, &newTxPower, status);
+            AdrImplementation(&newDataRate, &newTxPowerDbm, status);
 
             // Change the power back to the default if we don't want to change it
             if (!m_toggleTxPower)
             {
-                newTxPower = transmissionPower;
+                newTxPowerDbm = transmissionPowerDbm;
             }
 
-            if (newDataRate != SfToDr(spreadingFactor) || newTxPower != transmissionPower)
+            if (newDataRate != SfToDr(spreadingFactor) || newTxPowerDbm != transmissionPowerDbm)
             {
                 // Create a list with mandatory channel indexes
                 int channels[] = {0, 1, 2};
@@ -134,12 +134,11 @@ AdrComponent::BeforeSendingReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus>
                 // Repetitions Setting
                 const int rep = 1;
 
-                NS_LOG_DEBUG("Sending LinkAdrReq with DR = " << (unsigned)newDataRate
-                                                             << " and TP = " << (unsigned)newTxPower
-                                                             << " dBm");
+                NS_LOG_DEBUG("Sending LinkAdrReq with DR = "
+                             << (unsigned)newDataRate << " and TP = " << newTxPowerDbm << "dBm");
 
                 status->m_reply.frameHeader.AddLinkAdrReq(newDataRate,
-                                                          GetTxPowerIndex(newTxPower),
+                                                          GetTxPowerIndex(newTxPowerDbm),
                                                           enabledChannels,
                                                           rep);
                 status->m_reply.frameHeader.SetAsDownlink();
@@ -167,7 +166,7 @@ AdrComponent::OnFailedReply(Ptr<EndDeviceStatus> status, Ptr<NetworkStatus> netw
 
 void
 AdrComponent::AdrImplementation(uint8_t* newDataRate,
-                                uint8_t* newTxPower,
+                                double* newTxPower,
                                 Ptr<EndDeviceStatus> status)
 {
     // Compute the maximum or median SNR, based on the boolean value historyAveraging
@@ -197,7 +196,7 @@ AdrComponent::AdrImplementation(uint8_t* newDataRate,
     NS_LOG_DEBUG("Required SNR = " << req_SNR);
 
     // Get the device transmission power (dBm)
-    double transmissionPower = status->GetMac()->GetTransmissionPower();
+    double transmissionPower = status->GetMac()->GetTransmissionPowerDbm();
 
     NS_LOG_DEBUG("Transmission Power = " << transmissionPower);
 
@@ -430,7 +429,7 @@ AdrComponent::GetAverageSNR(EndDeviceStatus::ReceivedPacketList packetList, int 
 }
 
 uint8_t
-AdrComponent::GetTxPowerIndex(int txPower)
+AdrComponent::GetTxPowerIndex(double txPower)
 {
     NS_ASSERT_MSG(txPower >= 0 && txPower <= 14, "TxPower dBm value out of supported range");
     NS_ASSERT_MSG(fmod(txPower, 2) == 0, "Invalid TxPower value");

--- a/model/adr-component.h
+++ b/model/adr-component.h
@@ -65,10 +65,10 @@ class AdrComponent : public NetworkControllerComponent
      * https://doi.org/10.1109/NOMS.2018.8406255 .
      *
      * @param newDataRate [out] new data rate value selected for the end device.
-     * @param newTxPower [out] new tx power value selected for the end device.
+     * @param newTxPower [out] new tx power [dBm] value selected for the end device.
      * @param status State representation of the current end device.
      */
-    void AdrImplementation(uint8_t* newDataRate, uint8_t* newTxPower, Ptr<EndDeviceStatus> status);
+    void AdrImplementation(uint8_t* newDataRate, double* newTxPower, Ptr<EndDeviceStatus> status);
 
     /**
      * Convert spreading factor values [7:12] to respective data rate values [0:5].
@@ -152,7 +152,7 @@ class AdrComponent : public NetworkControllerComponent
      * @param txPower Transission ERP configuration [dBm].
      * @return TxPower parameter value as uint8_t.
      */
-    uint8_t GetTxPowerIndex(int txPower);
+    uint8_t GetTxPowerIndex(double txPower);
 
     enum CombiningMethod tpAveraging;      //!< TX power from gateways policy
     int historyRange;                      //!< Number of previous packets to consider

--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -530,9 +530,10 @@ ClassAEndDeviceLorawanMac::GetSecondReceiveWindowFrequency() const
 void
 ClassAEndDeviceLorawanMac::OnRxParamSetupReq(uint8_t rx1DrOffset,
                                              uint8_t rx2DataRate,
-                                             double frequency)
+                                             double frequencyHz)
 {
-    NS_LOG_FUNCTION(this << unsigned(rx1DrOffset) << unsigned(rx2DataRate) << frequency);
+    NS_LOG_FUNCTION(this << unsigned(rx1DrOffset) << unsigned(rx2DataRate)
+                         << uint32_t(frequencyHz));
 
     // Adapted from: github.com/Lora-net/SWL2001.git v4.3.1
     // For the time being, this implementation is valid for the EU868 region
@@ -553,7 +554,7 @@ ClassAEndDeviceLorawanMac::OnRxParamSetupReq(uint8_t rx1DrOffset,
         rx2DataRateAck = false;
     }
 
-    if (!m_channelHelper->IsFrequencyValid(frequency / 1e6))
+    if (!m_channelHelper->IsFrequencyValid(frequencyHz / 1e6))
     {
         NS_LOG_WARN("Invalid rx2 frequency");
         channelAck = false;
@@ -563,7 +564,7 @@ ClassAEndDeviceLorawanMac::OnRxParamSetupReq(uint8_t rx1DrOffset,
     {
         m_rx1DrOffset = rx1DrOffset;
         m_secondReceiveWindowDataRate = rx2DataRate;
-        m_secondReceiveWindowFrequencyMHz = frequency / 1e6;
+        m_secondReceiveWindowFrequencyMHz = frequencyHz / 1e6;
     }
 
     NS_LOG_INFO("Adding RxParamSetupAns reply");

--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -18,8 +18,6 @@
 
 #include "ns3/log.h"
 
-#include <algorithm>
-
 namespace ns3
 {
 namespace lorawan
@@ -450,7 +448,7 @@ ClassAEndDeviceLorawanMac::CloseSecondReceiveWindow()
 /////////////////////////
 
 Time
-ClassAEndDeviceLorawanMac::GetNextClassTransmissionDelay(Time waitingTime)
+ClassAEndDeviceLorawanMac::GetNextClassTransmissionDelay(Time waitTime)
 {
     NS_LOG_FUNCTION_NOARGS();
 
@@ -471,8 +469,8 @@ ClassAEndDeviceLorawanMac::GetNextClassTransmissionDelay(Time waitingTime)
                                      Seconds(m_receiveWindowDurationInSymbols * tSym);
 
             NS_LOG_DEBUG("Duration until endSecondRxWindow for new transmission:"
-                         << (endSecondRxWindow - Simulator::Now()).GetSeconds());
-            waitingTime = std::max(waitingTime, endSecondRxWindow - Simulator::Now());
+                         << (endSecondRxWindow - Now()).As(Time::S));
+            waitTime = Max(waitTime, endSecondRxWindow - Now());
         }
     }
     // This is a retransmitted packet, it can not be sent until the end of
@@ -482,15 +480,15 @@ ClassAEndDeviceLorawanMac::GetNextClassTransmissionDelay(Time waitingTime)
         double ack_timeout = m_uniformRV->GetValue(1, 3);
         // Compute the duration until ACK_TIMEOUT (It may be a negative number, but it doesn't
         // matter.)
-        Time retransmitWaitingTime =
-            Time(m_secondReceiveWindow.GetTs()) - Simulator::Now() + Seconds(ack_timeout);
+        Time retransmitWaitTime =
+            Time(m_secondReceiveWindow.GetTs()) - Now() + Seconds(ack_timeout);
 
-        NS_LOG_DEBUG("ack_timeout:" << ack_timeout << " retransmitWaitingTime:"
-                                    << retransmitWaitingTime.GetSeconds());
-        waitingTime = std::max(waitingTime, retransmitWaitingTime);
+        NS_LOG_DEBUG("ack_timeout:" << ack_timeout
+                                    << " retransmitWaitTime:" << retransmitWaitTime.As(Time::S));
+        waitTime = Max(waitTime, retransmitWaitTime);
     }
 
-    return waitingTime;
+    return waitTime;
 }
 
 uint8_t

--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -79,7 +79,7 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packetToSend)
     if (m_enableDRAdapt && (m_dataRate > 0) && (m_retxParams.retxLeft < m_nbTrans) &&
         (m_retxParams.retxLeft % 2 == 0))
     {
-        m_txPower = 14; // Reset transmission power
+        m_txPowerDbm = 14; // Reset transmission power
         m_dataRate = m_dataRate - 1;
     }
 
@@ -98,7 +98,7 @@ ClassAEndDeviceLorawanMac::SendToPhy(Ptr<Packet> packetToSend)
     Ptr<LogicalLoraChannel> txChannel = GetChannelForTx();
 
     NS_LOG_DEBUG("PacketToSend: " << packetToSend);
-    m_phy->Send(packetToSend, params, txChannel->GetFrequency(), m_txPower);
+    m_phy->Send(packetToSend, params, txChannel->GetFrequency(), m_txPowerDbm);
 
     //////////////////////////////////////////////
     // Register packet transmission for duty cycle

--- a/model/class-a-end-device-lorawan-mac.h
+++ b/model/class-a-end-device-lorawan-mac.h
@@ -157,7 +157,7 @@ class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
     // MAC command methods //
     /////////////////////////
 
-    void OnRxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency) override;
+    void OnRxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequencyHz) override;
 
   private:
     Time m_receiveDelay1; //!< The interval between when a packet is done sending and when the first

--- a/model/class-a-end-device-lorawan-mac.h
+++ b/model/class-a-end-device-lorawan-mac.h
@@ -109,14 +109,14 @@ class ClassAEndDeviceLorawanMac : public EndDeviceLorawanMac
     /////////////////////////
 
     /**
-     * Find the minimum waiting time before the next possible transmission based
+     * Find the minimum wait time before the next possible transmission based
      * on end device's Class Type.
      *
-     * @param waitingTime The minimum waiting time that has to be respected,
+     * @param waitTime The minimum wait time that has to be respected,
      * irrespective of the class (e.g., because of duty cycle limitations).
      * @return The Time value.
      */
-    Time GetNextClassTransmissionDelay(Time waitingTime) override;
+    Time GetNextClassTransmissionDelay(Time waitTime) override;
 
     /**
      * Get the data rate that will be used in the first receive window.

--- a/model/end-device-lora-phy.cc
+++ b/model/end-device-lora-phy.cc
@@ -62,7 +62,7 @@ EndDeviceLoraPhy::GetTypeId()
 // These will then be changed by helpers.
 EndDeviceLoraPhy::EndDeviceLoraPhy()
     : m_state(SLEEP),
-      m_frequency(868.1),
+      m_frequencyMHz(868.1),
       m_sf(7)
 {
 }
@@ -97,13 +97,13 @@ EndDeviceLoraPhy::IsTransmitting()
 bool
 EndDeviceLoraPhy::IsOnFrequency(double frequencyMHz)
 {
-    return m_frequency == frequencyMHz;
+    return m_frequencyMHz == frequencyMHz;
 }
 
 void
 EndDeviceLoraPhy::SetFrequency(double frequencyMHz)
 {
-    m_frequency = frequencyMHz;
+    m_frequencyMHz = frequencyMHz;
 }
 
 void

--- a/model/end-device-lora-phy.h
+++ b/model/end-device-lora-phy.h
@@ -263,7 +263,7 @@ class EndDeviceLoraPhy : public LoraPhy
     // static const double sensitivity[6]; //!< The sensitivity vector of this device to different
     // SFs
 
-    double m_frequency; //!< The frequency this device is listening on
+    double m_frequencyMHz; //!< The frequency [MHz] this device is listening on
 
     uint8_t m_sf; //!< The Spreading Factor this device is listening for
 

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -860,11 +860,11 @@ EndDeviceLorawanMac::OnDevStatusReq()
 
 void
 EndDeviceLorawanMac::OnNewChannelReq(uint8_t chIndex,
-                                     double frequency,
+                                     double frequencyHz,
                                      uint8_t minDataRate,
                                      uint8_t maxDataRate)
 {
-    NS_LOG_FUNCTION(this << unsigned(chIndex) << uint32_t(frequency) << unsigned(minDataRate)
+    NS_LOG_FUNCTION(this << unsigned(chIndex) << uint32_t(frequencyHz) << unsigned(minDataRate)
                          << unsigned(maxDataRate));
 
     NS_ASSERT_MSG(!(minDataRate & 0xF0), "minDataRate field > 4 bits");
@@ -884,7 +884,7 @@ EndDeviceLorawanMac::OnNewChannelReq(uint8_t chIndex,
     }
 
     // Valid Frequency
-    if (frequency != 0 && !m_channelHelper->IsFrequencyValid(frequency / 1e6))
+    if (frequencyHz != 0 && !m_channelHelper->IsFrequencyValid(frequencyHz / 1e6))
     {
         NS_LOG_WARN("[WARNING] Invalid frequency");
         channelFrequencyOk = false;
@@ -911,10 +911,10 @@ EndDeviceLorawanMac::OnNewChannelReq(uint8_t chIndex,
 
     if (dataRateRangeOk && channelFrequencyOk)
     {
-        auto channel = Create<LogicalLoraChannel>(frequency / 1e6, minDataRate, maxDataRate);
-        (frequency == 0) ? channel->DisableForUplink() : channel->EnableForUplink();
+        auto channel = Create<LogicalLoraChannel>(frequencyHz / 1e6, minDataRate, maxDataRate);
+        (frequencyHz == 0) ? channel->DisableForUplink() : channel->EnableForUplink();
         m_channelHelper->SetChannel(chIndex, channel);
-        NS_LOG_DEBUG("MacTxFrequency[" << unsigned(chIndex) << "]=" << uint32_t(frequency)
+        NS_LOG_DEBUG("MacTxFrequency[" << unsigned(chIndex) << "]=" << uint32_t(frequencyHz)
                                        << ", DrMin=" << unsigned(minDataRate)
                                        << ", DrMax=" << unsigned(maxDataRate));
     }

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -473,10 +473,10 @@ EndDeviceLorawanMac::TxFinished(Ptr<const Packet> packet)
 }
 
 Time
-EndDeviceLorawanMac::GetNextClassTransmissionDelay(Time waitingTime)
+EndDeviceLorawanMac::GetNextClassTransmissionDelay(Time waitTime)
 {
     NS_LOG_FUNCTION_NOARGS();
-    return waitingTime;
+    return waitTime;
 }
 
 Time
@@ -490,7 +490,7 @@ EndDeviceLorawanMac::GetNextTransmissionDelay()
     {
         if (channel && channel->IsEnabledForUplink()) // Skip empty frequency channel slots
         {
-            auto curr = m_channelHelper->GetWaitingTime(channel);
+            auto curr = m_channelHelper->GetWaitTime(channel);
             if (curr < waitTime)
             {
                 waitTime = curr;
@@ -514,7 +514,7 @@ EndDeviceLorawanMac::GetChannelForTx()
         {
             uint8_t minDr = channel->GetMinimumDataRate();
             uint8_t maxDr = channel->GetMaximumDataRate();
-            Time waitTime = m_channelHelper->GetWaitingTime(channel);
+            Time waitTime = m_channelHelper->GetWaitTime(channel);
             NS_LOG_DEBUG("Enabled channel: frequency="
                          << channel->GetFrequency() << "MHz, minDr=" << unsigned(minDr)
                          << ", maxDr=" << unsigned(maxDr) << ", waitTime=" << waitTime.As(Time::S));

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -152,7 +152,7 @@ EndDeviceLorawanMac::Send(Ptr<Packet> packet)
     // or because we are receiving, schedule a tx/retx later
 
     Time netxTxDelay = GetNextTransmissionDelay();
-    if (netxTxDelay != Seconds(0))
+    if (netxTxDelay.IsStrictlyPositive())
     {
         postponeTransmission(netxTxDelay, packet);
         return;
@@ -192,7 +192,7 @@ EndDeviceLorawanMac::postponeTransmission(Time netxTxDelay, Ptr<Packet> packet)
     m_nextTx = Simulator::Schedule(netxTxDelay, &EndDeviceLorawanMac::DoSend, this, packet);
     NS_LOG_WARN("Attempting to send, but the aggregate duty cycle won't allow it. Scheduling a tx "
                 "at a delay "
-                << netxTxDelay.GetSeconds() << ".");
+                << netxTxDelay.As(Time::S) << ".");
 }
 
 void
@@ -253,7 +253,7 @@ EndDeviceLorawanMac::DoSend(Ptr<Packet> packet)
             m_retxParams.packet = packet->Copy();
             m_retxParams.retxLeft = m_nbTrans;
             m_retxParams.waitingAck = true;
-            m_retxParams.firstAttempt = Simulator::Now();
+            m_retxParams.firstAttempt = Now();
             m_retxParams.retxLeft =
                 m_retxParams.retxLeft - 1; // decreasing the number of retransmissions
 
@@ -545,7 +545,7 @@ EndDeviceLorawanMac::resetRetransmissionParameters()
     m_retxParams.waitingAck = false;
     m_retxParams.retxLeft = m_nbTrans;
     m_retxParams.packet = nullptr;
-    m_retxParams.firstAttempt = Seconds(0);
+    m_retxParams.firstAttempt = Time(0);
 
     // Cancel next retransmissions, if any
     Simulator::Cancel(m_nextTx);

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -57,8 +57,8 @@ EndDeviceLorawanMac::GetTypeId()
                 MakeBooleanAccessor(&EndDeviceLorawanMac::m_adr),
                 MakeBooleanChecker())
             .AddTraceSource("TxPower",
-                            "Transmission power currently employed by this end device",
-                            MakeTraceSourceAccessor(&EndDeviceLorawanMac::m_txPower),
+                            "Transmission ERP [dBm] currently employed by this end device",
+                            MakeTraceSourceAccessor(&EndDeviceLorawanMac::m_txPowerDbm),
                             "ns3::TracedValueCallback::Double")
             .AddTraceSource("LastKnownLinkMargin",
                             "Last known demodulation margin in "
@@ -102,7 +102,7 @@ EndDeviceLorawanMac::EndDeviceLorawanMac()
     : m_enableDRAdapt(false),
       m_nbTrans(1),
       m_dataRate(0),
-      m_txPower(14),
+      m_txPowerDbm(14),
       m_codingRate(1),
       // LoraWAN default
       m_headerDisabled(false),
@@ -177,7 +177,7 @@ EndDeviceLorawanMac::Send(Ptr<Packet> packet)
     // retransmissions
     {
         // Make sure we can transmit at the current power on this channel
-        NS_ASSERT_MSG(m_txPower <= m_channelHelper->GetTxPowerForChannel(txChannel),
+        NS_ASSERT_MSG(m_txPowerDbm <= m_channelHelper->GetTxPowerForChannel(txChannel),
                       " The selected power is too high to be supported by this channel.");
         DoSend(packet);
     }
@@ -597,17 +597,17 @@ EndDeviceLorawanMac::GetDataRate()
 }
 
 void
-EndDeviceLorawanMac::SetTransmissionPower(uint8_t txPower)
+EndDeviceLorawanMac::SetTransmissionPowerDbm(double txPowerDbm)
 {
-    NS_LOG_FUNCTION(this << txPower);
-    m_txPower = txPower;
+    NS_LOG_FUNCTION(this << txPowerDbm);
+    m_txPowerDbm = txPowerDbm;
 }
 
-uint8_t
-EndDeviceLorawanMac::GetTransmissionPower()
+double
+EndDeviceLorawanMac::GetTransmissionPowerDbm()
 {
     NS_LOG_FUNCTION(this);
-    return m_txPower;
+    return m_txPowerDbm;
 }
 
 void
@@ -801,7 +801,7 @@ EndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
             }
             if (txPower != 0xF) // If value is 0xF, ignore config.
             {
-                m_txPower = GetDbmForTxPower(txPower);
+                m_txPowerDbm = GetDbmForTxPower(txPower);
             }
             m_nbTrans = (nbTrans == 0) ? 1 : nbTrans;
             if (dataRate != 0xF) // If value is 0xF, ignore config.
@@ -809,7 +809,7 @@ EndDeviceLorawanMac::OnLinkAdrReq(uint8_t dataRate,
                 m_dataRate = dataRate;
             }
             NS_LOG_DEBUG("MacTxDataRateAdr = " << unsigned(m_dataRate));
-            NS_LOG_DEBUG("MacTxPower = " << unsigned(m_txPower) << "dBm");
+            NS_LOG_DEBUG("MacTxPower = " << unsigned(m_txPowerDbm) << "dBm");
             NS_LOG_DEBUG("MacNbTrans = " << unsigned(m_nbTrans));
         }
     }

--- a/model/end-device-lorawan-mac.h
+++ b/model/end-device-lorawan-mac.h
@@ -151,16 +151,16 @@ class EndDeviceLorawanMac : public LorawanMac
     /**
      * Get the transmission power this end device is set to use.
      *
-     * @return The transmission power this device uses when transmitting.
+     * @return The transmission ERP [dBm] this device uses when transmitting.
      */
-    virtual uint8_t GetTransmissionPower();
+    double GetTransmissionPowerDbm();
 
     /**
      * Set the transmission power of this end device.
      *
-     * @param txPower The transmission ERP [dBm] value.
+     * @param txPowerDbm The transmission ERP [dBm] value.
      */
-    void SetTransmissionPower(uint8_t txPower);
+    void SetTransmissionPowerDbm(double txPowerDbm);
 
     /**
      * Set the network address of this device.
@@ -329,8 +329,9 @@ class EndDeviceLorawanMac : public LorawanMac
         m_enableDRAdapt; //!< Enable data rate adaptation (ADR) during the retransmission procedure.
     uint8_t m_nbTrans; //!< Default number of unacknowledged redundant transmissions of each packet.
     TracedValue<uint8_t> m_dataRate; //!< The data rate this device is using to transmit.
-    TracedValue<double> m_txPower;   //!< The transmission power this device is using to transmit.
-    uint8_t m_codingRate;            //!< The coding rate used by this device.
+    TracedValue<double>
+        m_txPowerDbm;      //!< The transmission ERP [dBm] this device is currently using.
+    uint8_t m_codingRate;  //!< The coding rate used by this device.
     bool m_headerDisabled; //!< Whether or not the LoRa PHY header is disabled for communications by
                            //!< this device.
     LoraDeviceAddress m_address; //!< The address of this device.

--- a/model/end-device-lorawan-mac.h
+++ b/model/end-device-lorawan-mac.h
@@ -282,9 +282,11 @@ class EndDeviceLorawanMac : public LorawanMac
      *
      * @param rx1DrOffset The first reception window data rate offset to set.
      * @param rx2DataRate The data rate to use for the second receive window.
-     * @param frequency The frequency [Hz] to use for the second receive window.
+     * @param frequencyHz The frequency [Hz] to use for the second receive window.
      */
-    virtual void OnRxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency) = 0;
+    virtual void OnRxParamSetupReq(uint8_t rx1DrOffset,
+                                   uint8_t rx2DataRate,
+                                   double frequencyHz) = 0;
 
     /**
      * Perform the actions that need to be taken when receiving a DevStatusReq command.
@@ -295,12 +297,12 @@ class EndDeviceLorawanMac : public LorawanMac
      * Perform the actions that need to be taken when receiving a NewChannelReq command.
      *
      * @param chIndex The ChIndex field of the received NewChannelReq command.
-     * @param frequency The Frequency field of the received NewChannelReq command.
+     * @param frequencyHz The Frequency [Hz] field of the received NewChannelReq command.
      * @param minDataRate The MinDR field of the received NewChannelReq command.
      * @param maxDataRate The MaxDR field of the received NewChannelReq command.
      */
     void OnNewChannelReq(uint8_t chIndex,
-                         double frequency,
+                         double frequencyHz,
                          uint8_t minDataRate,
                          uint8_t maxDataRate);
 

--- a/model/end-device-lorawan-mac.h
+++ b/model/end-device-lorawan-mac.h
@@ -339,13 +339,13 @@ class EndDeviceLorawanMac : public LorawanMac
     LoraDeviceAddress m_address; //!< The address of this device.
 
     /**
-     * Find the minimum waiting time before the next possible transmission based
+     * Find the minimum wait time before the next possible transmission based
      * on end device's Class Type.
      *
-     * @param waitingTime Currently known minimum waiting time, possibly raised by this function.
-     * @return The updated minimum waiting time in Time format.
+     * @param waitTime Currently known minimum wait time, possibly raised by this function.
+     * @return The updated minimum wait time in Time format.
      */
-    virtual Time GetNextClassTransmissionDelay(Time waitingTime);
+    virtual Time GetNextClassTransmissionDelay(Time waitTime);
 
     /**
      * Find a suitable channel for transmission. The channel is chosen among the
@@ -401,7 +401,7 @@ class EndDeviceLorawanMac : public LorawanMac
     /**
      * Find the base minimum wait time before the next possible transmission.
      *
-     * @return The base minimum waiting time.
+     * @return The base minimum wait time.
      */
     Time GetNextTransmissionDelay();
 

--- a/model/end-device-status.cc
+++ b/model/end-device-status.cc
@@ -184,10 +184,10 @@ EndDeviceStatus::SetFirstReceiveWindowSpreadingFactor(uint8_t sf)
 }
 
 void
-EndDeviceStatus::SetFirstReceiveWindowFrequency(double frequency)
+EndDeviceStatus::SetFirstReceiveWindowFrequency(double frequencyMHz)
 {
     NS_LOG_FUNCTION_NOARGS();
-    m_firstReceiveWindowFrequency = frequency;
+    m_firstReceiveWindowFrequency = frequencyMHz;
 }
 
 void
@@ -198,10 +198,10 @@ EndDeviceStatus::SetSecondReceiveWindowSpreadingFactor(uint8_t sf)
 }
 
 void
-EndDeviceStatus::SetSecondReceiveWindowFrequency(double frequency)
+EndDeviceStatus::SetSecondReceiveWindowFrequency(double frequencyMHz)
 {
     NS_LOG_FUNCTION_NOARGS();
-    m_secondReceiveWindowFrequency = frequency;
+    m_secondReceiveWindowFrequency = frequencyMHz;
 }
 
 void
@@ -254,7 +254,7 @@ EndDeviceStatus::InsertReceivedPacket(Ptr<const Packet> receivedPacket, const Ad
     // Update Information on the received packet
     ReceivedPacketInfo info;
     info.sf = tag.GetSpreadingFactor();
-    info.frequency = tag.GetFrequency();
+    info.frequencyMHz = tag.GetFrequency();
     info.packet = receivedPacket;
 
     double rcvPower = tag.GetReceivePower();

--- a/model/end-device-status.cc
+++ b/model/end-device-status.cc
@@ -288,7 +288,7 @@ EndDeviceStatus::InsertReceivedPacket(Ptr<const Packet> receivedPacket, const Ad
             GatewayList& gwList = it->second.gwList;
 
             PacketInfoPerGw gwInfo;
-            gwInfo.receivedTime = Simulator::Now();
+            gwInfo.receivedTime = Now();
             gwInfo.rxPower = rcvPower;
             gwInfo.gwAddress = gwAddress;
             gwList.insert(std::pair<Address, PacketInfoPerGw>(gwAddress, gwInfo));
@@ -302,7 +302,7 @@ EndDeviceStatus::InsertReceivedPacket(Ptr<const Packet> receivedPacket, const Ad
     {
         NS_LOG_INFO("Packet was received for the first time");
         PacketInfoPerGw gwInfo;
-        gwInfo.receivedTime = Simulator::Now();
+        gwInfo.receivedTime = Now();
         gwInfo.rxPower = rcvPower;
         gwInfo.gwAddress = gwAddress;
         info.gwList.insert(std::pair<Address, PacketInfoPerGw>(gwAddress, gwInfo));

--- a/model/end-device-status.h
+++ b/model/end-device-status.h
@@ -154,7 +154,7 @@ class EndDeviceStatus : public Object
         Ptr<const Packet> packet = nullptr; //!< The received packet
         GatewayList gwList;                 //!< List of gateways that received this packet
         uint8_t sf;                         //!< Spreading factor used to send this packet
-        double frequency;                   //!< Carrier frequency [MHz] used to send this packet
+        double frequencyMHz;                //!< Carrier frequency [MHz] used to send this packet
     };
 
     /**
@@ -230,9 +230,9 @@ class EndDeviceStatus : public Object
     /**
      * Set the first window frequency of this device.
      *
-     * @param frequency The frequency [MHz].
+     * @param frequencyMHz The frequency [MHz].
      */
-    void SetFirstReceiveWindowFrequency(double frequency);
+    void SetFirstReceiveWindowFrequency(double frequencyMHz);
 
     /**
      * Set the spreading factor this device is using in the second receive window.
@@ -244,9 +244,9 @@ class EndDeviceStatus : public Object
     /**
      * Set the second window frequency of this device.
      *
-     * @param frequency The frequency [MHz].
+     * @param frequencyMHz The frequency [MHz].
      */
-    void SetSecondReceiveWindowFrequency(double frequency);
+    void SetSecondReceiveWindowFrequency(double frequencyMHz);
 
     /**
      * Set the reply packet mac header.

--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -60,7 +60,7 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     packet->AddPacketTag(tag);
 
     // Make sure we can transmit this packet
-    if (GetWaitTime(frequencyMHz) > Time(0))
+    if (GetWaitTime(frequencyMHz).IsStrictlyPositive())
     {
         // We cannot send now!
         NS_LOG_WARN("Trying to send a packet but Duty Cycle won't allow it. Aborting.");
@@ -79,7 +79,7 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     // Get the duration
     Time duration = LoraPhy::GetOnAirTime(packet, params);
 
-    NS_LOG_DEBUG("Duration: " << duration.GetSeconds());
+    NS_LOG_DEBUG("Duration: " << duration.As(Time::S));
 
     // Find the channel with the desired frequency
     double sendingPower = m_channelHelper->GetTxPowerForChannel(frequencyMHz);

--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -52,15 +52,15 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     LoraTag tag;
     packet->RemovePacketTag(tag);
     uint8_t dataRate = tag.GetDataRate();
-    double frequency = tag.GetFrequency();
+    double frequencyMHz = tag.GetFrequency();
     NS_LOG_DEBUG("DR: " << unsigned(dataRate));
     NS_LOG_DEBUG("SF: " << unsigned(GetSfFromDataRate(dataRate)));
     NS_LOG_DEBUG("BW: " << GetBandwidthFromDataRate(dataRate));
-    NS_LOG_DEBUG("Freq: " << frequency << " MHz");
+    NS_LOG_DEBUG("Freq: " << frequencyMHz << " MHz");
     packet->AddPacketTag(tag);
 
     // Make sure we can transmit this packet
-    if (GetWaitingTime(frequency) > Time(0))
+    if (GetWaitingTime(frequencyMHz) > Time(0))
     {
         // We cannot send now!
         NS_LOG_WARN("Trying to send a packet but Duty Cycle won't allow it. Aborting.");
@@ -82,13 +82,13 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     NS_LOG_DEBUG("Duration: " << duration.GetSeconds());
 
     // Find the channel with the desired frequency
-    double sendingPower = m_channelHelper->GetTxPowerForChannel(frequency);
+    double sendingPower = m_channelHelper->GetTxPowerForChannel(frequencyMHz);
 
     // Add the event to the channelHelper to keep track of duty cycle
-    m_channelHelper->AddEvent(duration, frequency);
+    m_channelHelper->AddEvent(duration, frequencyMHz);
 
     // Send the packet to the PHY layer to send it on the channel
-    m_phy->Send(packet, params, frequency, sendingPower);
+    m_phy->Send(packet, params, frequencyMHz, sendingPower);
 
     m_sentNewPacket(packet);
 }
@@ -138,11 +138,11 @@ GatewayLorawanMac::TxFinished(Ptr<const Packet> packet)
 }
 
 Time
-GatewayLorawanMac::GetWaitingTime(double frequency)
+GatewayLorawanMac::GetWaitingTime(double frequencyMHz)
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    return m_channelHelper->GetWaitingTime(frequency);
+    return m_channelHelper->GetWaitingTime(frequencyMHz);
 }
 } // namespace lorawan
 } // namespace ns3

--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -60,7 +60,7 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     packet->AddPacketTag(tag);
 
     // Make sure we can transmit this packet
-    if (GetWaitingTime(frequencyMHz) > Time(0))
+    if (GetWaitTime(frequencyMHz) > Time(0))
     {
         // We cannot send now!
         NS_LOG_WARN("Trying to send a packet but Duty Cycle won't allow it. Aborting.");
@@ -138,11 +138,11 @@ GatewayLorawanMac::TxFinished(Ptr<const Packet> packet)
 }
 
 Time
-GatewayLorawanMac::GetWaitingTime(double frequencyMHz)
+GatewayLorawanMac::GetWaitTime(double frequencyMHz)
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    return m_channelHelper->GetWaitingTime(frequencyMHz);
+    return m_channelHelper->GetWaitTime(frequencyMHz);
 }
 } // namespace lorawan
 } // namespace ns3

--- a/model/gateway-lorawan-mac.h
+++ b/model/gateway-lorawan-mac.h
@@ -59,7 +59,7 @@ class GatewayLorawanMac : public LorawanMac
      * @param frequencyMHz The frequency value [MHz].
      * @return The next transmission time.
      */
-    Time GetWaitingTime(double frequencyMHz);
+    Time GetWaitTime(double frequencyMHz);
 
   private:
   protected:

--- a/model/gateway-lorawan-mac.h
+++ b/model/gateway-lorawan-mac.h
@@ -56,10 +56,10 @@ class GatewayLorawanMac : public LorawanMac
     /**
      * Return the next time at which we will be able to transmit on the specified frequency.
      *
-     * @param frequency The frequency value [MHz].
+     * @param frequencyMHz The frequency value [MHz].
      * @return The next transmission time.
      */
-    Time GetWaitingTime(double frequency);
+    Time GetWaitingTime(double frequencyMHz);
 
   private:
   protected:

--- a/model/gateway-status.cc
+++ b/model/gateway-status.cc
@@ -100,11 +100,11 @@ GatewayStatus::IsAvailableForTransmission(double frequencyMHz)
     }
 
     // Check that the gateway is not constrained by the duty cycle
-    Time waitingTime = m_gatewayMac->GetWaitingTime(frequencyMHz);
-    if (waitingTime > Seconds(0))
+    Time waitTime = m_gatewayMac->GetWaitTime(frequencyMHz);
+    if (waitTime.IsStrictlyPositive())
     {
         NS_LOG_INFO("Gateway cannot be used because of duty cycle");
-        NS_LOG_INFO("Waiting time at current gateway: " << waitingTime.GetSeconds() << " seconds");
+        NS_LOG_INFO("Wait time at current gateway: " << waitTime.As(Time::S));
 
         return false;
     }

--- a/model/gateway-status.cc
+++ b/model/gateway-status.cc
@@ -41,7 +41,7 @@ GatewayStatus::GatewayStatus(Address address,
     : m_address(address),
       m_netDevice(netDevice),
       m_gatewayMac(gwMac),
-      m_nextTransmissionTime(Seconds(0))
+      m_nextTransmissionTime(Time(0))
 {
     NS_LOG_FUNCTION(this);
 }
@@ -86,7 +86,7 @@ GatewayStatus::IsAvailableForTransmission(double frequencyMHz)
     // We can't send multiple packets at once, see SX1301 V2.01 page 29
 
     // Check that the gateway was not already "booked"
-    if (m_nextTransmissionTime > Simulator::Now() - MilliSeconds(1))
+    if (m_nextTransmissionTime > Now() - MilliSeconds(1))
     {
         NS_LOG_INFO("This gateway is already booked for a transmission");
         return false;

--- a/model/gateway-status.cc
+++ b/model/gateway-status.cc
@@ -81,7 +81,7 @@ GatewayStatus::GetGatewayMac()
 }
 
 bool
-GatewayStatus::IsAvailableForTransmission(double frequency)
+GatewayStatus::IsAvailableForTransmission(double frequencyMHz)
 {
     // We can't send multiple packets at once, see SX1301 V2.01 page 29
 
@@ -100,7 +100,7 @@ GatewayStatus::IsAvailableForTransmission(double frequency)
     }
 
     // Check that the gateway is not constrained by the duty cycle
-    Time waitingTime = m_gatewayMac->GetWaitingTime(frequency);
+    Time waitingTime = m_gatewayMac->GetWaitingTime(frequencyMHz);
     if (waitingTime > Seconds(0))
     {
         NS_LOG_INFO("Gateway cannot be used because of duty cycle");

--- a/model/gateway-status.h
+++ b/model/gateway-status.h
@@ -97,10 +97,11 @@ class GatewayStatus : public Object
      * Query whether or not this gateway is available for immediate transmission
      * on this frequency.
      *
-     * @param frequency The frequency at which the gateway's availability should be queried.
+     * @param frequencyMHz The frequency [MHz] at which the gateway's availability should be
+     * queried.
      * @return True if the gateway's available, false otherwise.
      */
-    bool IsAvailableForTransmission(double frequency);
+    bool IsAvailableForTransmission(double frequencyMHz);
 
     /**
      * Set the time of the next scheduled transmission for the gateway.

--- a/model/logical-lora-channel-helper.cc
+++ b/model/logical-lora-channel-helper.cc
@@ -69,22 +69,22 @@ LogicalLoraChannelHelper::AddSubBand(Ptr<SubBand> subBand)
 }
 
 Time
-LogicalLoraChannelHelper::GetWaitingTime(Ptr<LogicalLoraChannel> channel) const
+LogicalLoraChannelHelper::GetWaitTime(Ptr<LogicalLoraChannel> channel) const
 {
     NS_LOG_FUNCTION(this << channel);
-    return GetWaitingTime(channel->GetFrequency());
+    return GetWaitTime(channel->GetFrequency());
 }
 
 Time
-LogicalLoraChannelHelper::GetWaitingTime(double frequencyMHz) const
+LogicalLoraChannelHelper::GetWaitTime(double frequencyMHz) const
 {
     NS_LOG_FUNCTION(this << frequencyMHz);
     auto subBand = GetSubBandFromFrequency(frequencyMHz);
     NS_ASSERT_MSG(subBand, "Input frequency is out-of-band");
-    Time waitingTime = subBand->GetNextTransmissionTime() - Now();
-    waitingTime = Max(waitingTime, Time(0)); // Handle negative values
-    NS_LOG_DEBUG("waitingTime=" << waitingTime.As(Time::S));
-    return waitingTime;
+    Time waitTime = subBand->GetNextTransmissionTime() - Now();
+    waitTime = Max(waitTime, Time(0)); // Handle negative values
+    NS_LOG_DEBUG("waitTime=" << waitTime.As(Time::S));
+    return waitTime;
 }
 
 void

--- a/model/logical-lora-channel-helper.h
+++ b/model/logical-lora-channel-helper.h
@@ -50,20 +50,20 @@ class LogicalLoraChannelHelper : public SimpleRefCount<LogicalLoraChannelHelper>
     /**
      * Get the time it is necessary to wait for before transmitting on a given channel.
      *
-     * @param channel A pointer to the channel we want to know the waiting time for.
-     * @return A Time instance containing the waiting time before transmission is allowed on the
+     * @param channel A pointer to the channel we want to know the wait time for.
+     * @return A Time instance containing the wait time before transmission is allowed on the
      * channel.
      */
-    Time GetWaitingTime(Ptr<LogicalLoraChannel> channel) const;
+    Time GetWaitTime(Ptr<LogicalLoraChannel> channel) const;
 
     /**
      * Get the time it is necessary to wait for before transmitting on a given channel.
      *
-     * @param frequencyMHz The channel frequency [MHz] we want to know the waiting time of for.
-     * @return A Time instance containing the waiting time before transmission is allowed on the
+     * @param frequencyMHz The channel frequency [MHz] we want to know the wait time of for.
+     * @return A Time instance containing the wait time before transmission is allowed on the
      * channel.
      */
-    Time GetWaitingTime(double frequencyMHz) const;
+    Time GetWaitTime(double frequencyMHz) const;
 
     /**
      * Register the transmission of a packet.

--- a/model/logical-lora-channel.cc
+++ b/model/logical-lora-channel.cc
@@ -19,8 +19,10 @@ namespace lorawan
 
 NS_LOG_COMPONENT_DEFINE("LogicalLoraChannel");
 
-LogicalLoraChannel::LogicalLoraChannel(double frequency, uint8_t minDataRate, uint8_t maxDataRate)
-    : m_frequency(frequency),
+LogicalLoraChannel::LogicalLoraChannel(double frequencyMHz,
+                                       uint8_t minDataRate,
+                                       uint8_t maxDataRate)
+    : m_frequencyMHz(frequencyMHz),
       m_minDataRate(minDataRate),
       m_maxDataRate(maxDataRate),
       m_enabledForUplink(true)
@@ -31,7 +33,7 @@ LogicalLoraChannel::LogicalLoraChannel(double frequency, uint8_t minDataRate, ui
 double
 LogicalLoraChannel::GetFrequency() const
 {
-    return m_frequency;
+    return m_frequencyMHz;
 }
 
 uint8_t

--- a/model/logical-lora-channel.h
+++ b/model/logical-lora-channel.h
@@ -34,11 +34,11 @@ class LogicalLoraChannel : public SimpleRefCount<LogicalLoraChannel>
     /**
      * Constructor providing initialization of frequency and data rate limits.
      *
-     * @param frequency This channel's frequency [MHz].
+     * @param frequencyMHz This channel's frequency [MHz].
      * @param minDataRate This channel's minimum data rate.
      * @param maxDataRate This channel's maximum data rate.
      */
-    LogicalLoraChannel(double frequency, uint8_t minDataRate, uint8_t maxDataRate);
+    LogicalLoraChannel(double frequencyMHz, uint8_t minDataRate, uint8_t maxDataRate);
 
     /**
      * Get the frequency (MHz).
@@ -79,7 +79,7 @@ class LogicalLoraChannel : public SimpleRefCount<LogicalLoraChannel>
     bool IsEnabledForUplink() const;
 
   private:
-    double m_frequency;      //!< The central frequency of this channel, in MHz.
+    double m_frequencyMHz;   //!< The central frequency of this channel, in MHz.
     uint8_t m_minDataRate;   //!< The minimum data rate that is allowed on this channel.
     uint8_t m_maxDataRate;   //!< The maximum data rate that is allowed on this channel.
     bool m_enabledForUplink; //!< Whether this channel can be used for uplink or not.

--- a/model/lora-channel.cc
+++ b/model/lora-channel.cc
@@ -202,7 +202,7 @@ std::ostream&
 operator<<(std::ostream& os, const LoraChannelParameters& params)
 {
     os << "(rxPowerDbm: " << params.rxPowerDbm << ", SF: " << unsigned(params.sf)
-       << ", durationSec: " << params.duration.GetSeconds()
+       << ", durationSec: " << params.duration.As(Time::S)
        << ", frequencyMHz: " << params.frequencyMHz << ")";
     return os;
 }

--- a/model/lora-frame-header.cc
+++ b/model/lora-frame-header.cc
@@ -434,12 +434,13 @@ LoraFrameHeader::AddDutyCycleAns()
 }
 
 void
-LoraFrameHeader::AddRxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency)
+LoraFrameHeader::AddRxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequencyHz)
 {
-    NS_LOG_FUNCTION(this << unsigned(rx1DrOffset) << unsigned(rx2DataRate) << frequency);
+    NS_LOG_FUNCTION(this << unsigned(rx1DrOffset) << unsigned(rx2DataRate)
+                         << uint32_t(frequencyHz));
     // Evaluate whether to eliminate this assert in case new offsets can be defined.
     NS_ASSERT(0 <= rx1DrOffset && rx1DrOffset <= 5);
-    auto command = Create<RxParamSetupReq>(rx1DrOffset, rx2DataRate, frequency);
+    auto command = Create<RxParamSetupReq>(rx1DrOffset, rx2DataRate, frequencyHz);
     m_macCommands.emplace_back(command);
     m_fOptsLen += command->GetSerializedSize();
 }
@@ -464,13 +465,13 @@ LoraFrameHeader::AddDevStatusReq()
 
 void
 LoraFrameHeader::AddNewChannelReq(uint8_t chIndex,
-                                  double frequency,
+                                  double frequencyHz,
                                   uint8_t minDataRate,
                                   uint8_t maxDataRate)
 {
-    NS_LOG_FUNCTION(this << unsigned(chIndex) << frequency << unsigned(minDataRate)
+    NS_LOG_FUNCTION(this << unsigned(chIndex) << uint32_t(frequencyHz) << unsigned(minDataRate)
                          << unsigned(maxDataRate));
-    auto command = Create<NewChannelReq>(chIndex, frequency, minDataRate, maxDataRate);
+    auto command = Create<NewChannelReq>(chIndex, frequencyHz, minDataRate, maxDataRate);
     m_macCommands.emplace_back(command);
     m_fOptsLen += command->GetSerializedSize();
 }

--- a/model/lora-frame-header.h
+++ b/model/lora-frame-header.h
@@ -270,9 +270,9 @@ class LoraFrameHeader : public Header
      *
      * @param rx1DrOffset The requested data rate offset for the first receive window.
      * @param rx2DataRate The requested data rate for the second receive window.
-     * @param frequency The frequency at which to listen for the second receive window.
+     * @param frequencyHz The frequency [Hz] at which to listen for the second receive window.
      */
-    void AddRxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency);
+    void AddRxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequencyHz);
 
     /**
      * Add a RxParamSetupAns command.
@@ -288,12 +288,12 @@ class LoraFrameHeader : public Header
      * Add a NewChannelReq command with provided fields.
      *
      * @param chIndex The ChIndex field.
-     * @param frequency The Frequency field.
+     * @param frequencyHz The Frequency field in Hz.
      * @param minDataRate The MinDR field.
      * @param maxDataRate The MaxDR field.
      */
     void AddNewChannelReq(uint8_t chIndex,
-                          double frequency,
+                          double frequencyHz,
                           uint8_t minDataRate,
                           uint8_t maxDataRate);
 

--- a/model/lora-interference-helper.cc
+++ b/model/lora-interference-helper.cc
@@ -30,7 +30,7 @@ LoraInterferenceHelper::Event::Event(Time duration,
                                      uint8_t spreadingFactor,
                                      Ptr<Packet> packet,
                                      double frequencyMHz)
-    : m_startTime(Simulator::Now()),
+    : m_startTime(Now()),
       m_endTime(m_startTime + duration),
       m_sf(spreadingFactor),
       m_rxPowerdBm(rxPowerdBm),
@@ -92,7 +92,7 @@ LoraInterferenceHelper::Event::GetFrequency() const
 void
 LoraInterferenceHelper::Event::Print(std::ostream& stream) const
 {
-    stream << "(" << m_startTime.GetSeconds() << " s - " << m_endTime.GetSeconds() << " s), SF"
+    stream << "(" << m_startTime.As(Time::S) << " - " << m_endTime.As(Time::S) << "), SF"
            << unsigned(m_sf) << ", " << m_rxPowerdBm << " dBm, " << m_frequencyMHz << " MHz";
 }
 
@@ -187,7 +187,7 @@ LoraInterferenceHelper::Add(Time duration,
                             Ptr<Packet> packet,
                             double frequencyMHz)
 {
-    NS_LOG_FUNCTION(this << duration.GetSeconds() << rxPower << unsigned(spreadingFactor) << packet
+    NS_LOG_FUNCTION(this << duration << rxPower << unsigned(spreadingFactor) << packet
                          << frequencyMHz);
 
     // Create an event based on the parameters
@@ -218,7 +218,7 @@ LoraInterferenceHelper::CleanOldEvents()
     // Cycle the events, and clean up if an event is old.
     for (auto it = m_events.begin(); it != m_events.end();)
     {
-        if ((*it)->GetEndTime() + oldEventThreshold < Simulator::Now())
+        if ((*it)->GetEndTime() + oldEventThreshold < Now())
         {
             it = m_events.erase(it);
         }
@@ -266,7 +266,7 @@ LoraInterferenceHelper::IsDestroyedByInterference(Ptr<LoraInterferenceHelper::Ev
     double frequencyMHz = event->GetFrequency();
 
     // Handy information about the time frame when the packet was received
-    Time now = Simulator::Now();
+    Time now = Now();
     Time duration = event->GetDuration();
     Time packetStartTime = now - duration;
 
@@ -308,7 +308,7 @@ LoraInterferenceHelper::IsDestroyedByInterference(Ptr<LoraInterferenceHelper::Ev
         // Compute the fraction of time the two events are overlapping
         Time overlap = GetOverlapTime(event, interferer);
 
-        NS_LOG_DEBUG("The two events overlap for " << overlap.GetSeconds() << " s.");
+        NS_LOG_DEBUG("The two events overlap for " << overlap.As(Time::S));
 
         // Compute the equivalent energy of the interference
         // Power [mW] = 10^(Power[dBm]/10)
@@ -387,7 +387,7 @@ LoraInterferenceHelper::GetOverlapTime(Ptr<LoraInterferenceHelper::Event> event1
     // Non-overlapping events
     if (e1 <= s2 || e2 <= s1)
     {
-        overlap = Seconds(0);
+        overlap = Time(0);
     }
     // event1 before event2
     else if (s1 < s2)

--- a/model/lora-interference-helper.cc
+++ b/model/lora-interference-helper.cc
@@ -263,7 +263,7 @@ LoraInterferenceHelper::IsDestroyedByInterference(Ptr<LoraInterferenceHelper::Ev
     // Gather information about the event
     double rxPowerDbm = event->GetRxPowerdBm();
     uint8_t sf = event->GetSpreadingFactor();
-    double frequency = event->GetFrequency();
+    double frequencyMHz = event->GetFrequency();
 
     // Handy information about the time frame when the packet was received
     Time now = Simulator::Now();
@@ -285,7 +285,7 @@ LoraInterferenceHelper::IsDestroyedByInterference(Ptr<LoraInterferenceHelper::Ev
         // Only consider the current event if the channel is the same: we
         // assume there's no interchannel interference. Also skip the current
         // event if it's the same that we want to analyze.
-        if (!(interferer->GetFrequency() == frequency) || interferer == event)
+        if (!(interferer->GetFrequency() == frequencyMHz) || interferer == event)
         {
             NS_LOG_DEBUG("Different channel or same event");
             it++;

--- a/model/lora-interference-helper.h
+++ b/model/lora-interference-helper.h
@@ -108,7 +108,7 @@ class LoraInterferenceHelper
         /**
          * Get the frequency this event was on.
          *
-         * @return The carrier frequency as a double.
+         * @return The carrier frequency [MHz] as a double.
          */
         double GetFrequency() const;
 

--- a/model/lora-net-device.cc
+++ b/model/lora-net-device.cc
@@ -188,7 +188,7 @@ LoraNetDevice::IsLinkUp() const
 {
     NS_LOG_FUNCTION(this);
 
-    return m_phy != nullptr;
+    return (bool)(m_phy);
 }
 
 void

--- a/model/lora-phy.h
+++ b/model/lora-phy.h
@@ -153,11 +153,11 @@ class LoraPhy : public Object
     /**
      * Whether this device is listening on the specified frequency or not.
      *
-     * @param frequency The frequency to query.
+     * @param frequencyMHz The frequency [MHz] to query.
      * @return True if the device is listening on that frequency, false
      * otherwise.
      */
-    virtual bool IsOnFrequency(double frequency) = 0;
+    virtual bool IsOnFrequency(double frequencyMHz) = 0;
 
     /**
      * Set the callback to call upon successful reception of a packet.

--- a/model/lora-radio-energy-model.cc
+++ b/model/lora-radio-energy-model.cc
@@ -210,8 +210,8 @@ LoraRadioEnergyModel::ChangeState(int newState)
 {
     NS_LOG_FUNCTION(this << newState);
 
-    Time duration = Simulator::Now() - m_lastUpdateTime;
-    NS_ASSERT(duration.GetNanoSeconds() >= 0); // check if duration is valid
+    Time duration = Now() - m_lastUpdateTime;
+    NS_ASSERT(duration.IsPositive()); // check if duration is valid
 
     // energy to decrease = current * voltage * time
     double energyToDecrease = 0.0;
@@ -238,7 +238,7 @@ LoraRadioEnergyModel::ChangeState(int newState)
     m_totalEnergyConsumption += energyToDecrease;
 
     // update last update time stamp
-    m_lastUpdateTime = Simulator::Now();
+    m_lastUpdateTime = Now();
 
     m_nPendingChangeState++;
 
@@ -357,8 +357,8 @@ LoraRadioEnergyModel::SetLoraRadioState(const EndDeviceLoraPhy::State state)
         stateName = "SLEEP";
         break;
     }
-    NS_LOG_DEBUG("LoraRadioEnergyModel:Switching to state: "
-                 << stateName << " at time = " << Simulator::Now().GetSeconds() << " s");
+    NS_LOG_DEBUG("LoraRadioEnergyModel:Switching to state: " << stateName
+                                                             << " at time = " << Now().As(Time::S));
 }
 
 // -------------------------------------------------------------------------- //

--- a/model/lora-tag.cc
+++ b/model/lora-tag.cc
@@ -37,7 +37,7 @@ LoraTag::LoraTag(uint8_t sf, uint8_t destroyedBy)
       m_destroyedBy(destroyedBy),
       m_receivePower(0),
       m_dataRate(0),
-      m_frequency(0)
+      m_frequencyMHz(0)
 {
 }
 
@@ -60,7 +60,7 @@ LoraTag::Serialize(TagBuffer i) const
     i.WriteU8(m_destroyedBy);
     i.WriteDouble(m_receivePower);
     i.WriteU8(m_dataRate);
-    i.WriteDouble(m_frequency);
+    i.WriteDouble(m_frequencyMHz);
 }
 
 void
@@ -70,7 +70,7 @@ LoraTag::Deserialize(TagBuffer i)
     m_destroyedBy = i.ReadU8();
     m_receivePower = i.ReadDouble();
     m_dataRate = i.ReadU8();
-    m_frequency = i.ReadDouble();
+    m_frequencyMHz = i.ReadDouble();
 }
 
 void
@@ -116,15 +116,15 @@ LoraTag::SetReceivePower(double receivePower)
 }
 
 void
-LoraTag::SetFrequency(double frequency)
+LoraTag::SetFrequency(double frequencyMHz)
 {
-    m_frequency = frequency;
+    m_frequencyMHz = frequencyMHz;
 }
 
 double
 LoraTag::GetFrequency() const
 {
-    return m_frequency;
+    return m_frequencyMHz;
 }
 
 uint8_t

--- a/model/lora-tag.h
+++ b/model/lora-tag.h
@@ -98,9 +98,9 @@ class LoraTag : public Tag
      * - It is used by the network server to signal to the gateway the frequency of a downlink
      * packet.
      *
-     * @param frequency The frequency value [MHz].
+     * @param frequencyMHz The frequency value [MHz].
      */
-    void SetFrequency(double frequency);
+    void SetFrequency(double frequencyMHz);
 
     /**
      * Get the frequency of the packet.
@@ -134,7 +134,7 @@ class LoraTag : public Tag
     uint8_t m_destroyedBy; //!< The Spreading Factor that destroyed the packet.
     double m_receivePower; //!< The reception power of this packet.
     uint8_t m_dataRate;    //!< The data rate that needs to be used to send this packet.
-    double m_frequency;    //!< The frequency of this packet
+    double m_frequencyMHz; //!< The frequency [MHz] of this packet
 };
 } // namespace lorawan
 } // namespace ns3

--- a/model/mac-command.cc
+++ b/model/mac-command.cc
@@ -474,12 +474,13 @@ RxParamSetupReq::RxParamSetupReq()
     m_serializedSize = 5;
 }
 
-RxParamSetupReq::RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency)
+RxParamSetupReq::RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequencyHz)
     : m_rx1DrOffset(rx1DrOffset),
       m_rx2DataRate(rx2DataRate),
-      m_frequency(frequency)
+      m_frequencyHz(frequencyHz)
 {
-    NS_LOG_FUNCTION(this << unsigned(rx1DrOffset) << unsigned(rx2DataRate) << frequency);
+    NS_LOG_FUNCTION(this << unsigned(rx1DrOffset) << unsigned(rx2DataRate)
+                         << uint32_t(frequencyHz));
     NS_ASSERT_MSG(!(rx1DrOffset & 0xF8), "rx1DrOffset > 3 bits");
     NS_ASSERT_MSG(!(rx2DataRate & 0xF0), "rx2DataRate > 4 bits");
     m_commandType = RX_PARAM_SETUP_REQ;
@@ -492,7 +493,7 @@ RxParamSetupReq::Serialize(Buffer::Iterator& start) const
     NS_LOG_FUNCTION(this);
     start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8((m_rx1DrOffset & 0b111) << 4 | (m_rx2DataRate & 0b1111));
-    uint32_t encodedFrequency = m_frequency / 100;
+    uint32_t encodedFrequency = m_frequencyHz / 100;
     // Frequency is in little endian (lsb -> msb)
     start.WriteU8(encodedFrequency);       // Least significant byte
     start.WriteU8(encodedFrequency >> 8);  // Middle byte
@@ -512,7 +513,7 @@ RxParamSetupReq::Deserialize(Buffer::Iterator& start)
     encodedFrequency += start.ReadU8();       // Least significant byte
     encodedFrequency += start.ReadU8() << 8;  // Middle byte
     encodedFrequency += start.ReadU8() << 16; // Most significant byte
-    m_frequency = encodedFrequency * 100;
+    m_frequencyHz = encodedFrequency * 100;
     return m_serializedSize;
 }
 
@@ -523,7 +524,7 @@ RxParamSetupReq::Print(std::ostream& os) const
     os << "RxParamSetupReq(";
     os << "RX1DROffset=" << unsigned(m_rx1DrOffset);
     os << ", RX2DataRate=" << unsigned(m_rx2DataRate);
-    os << ", Frequency=" << uint32_t(m_frequency);
+    os << ", Frequency=" << uint32_t(m_frequencyHz);
     os << ")";
 }
 
@@ -545,7 +546,7 @@ double
 RxParamSetupReq::GetFrequency()
 {
     NS_LOG_FUNCTION(this);
-    return m_frequency;
+    return m_frequencyHz;
 }
 
 /////////////////////
@@ -731,11 +732,11 @@ NewChannelReq::NewChannelReq()
 }
 
 NewChannelReq::NewChannelReq(uint8_t chIndex,
-                             double frequency,
+                             double frequencyHz,
                              uint8_t minDataRate,
                              uint8_t maxDataRate)
     : m_chIndex(chIndex),
-      m_frequency(frequency),
+      m_frequencyHz(frequencyHz),
       m_minDataRate(minDataRate),
       m_maxDataRate(maxDataRate)
 {
@@ -752,7 +753,7 @@ NewChannelReq::Serialize(Buffer::Iterator& start) const
     NS_LOG_FUNCTION(this);
     start.WriteU8(GetCIDFromMacCommand(m_commandType)); // Write the CID
     start.WriteU8(m_chIndex);
-    uint32_t encodedFrequency = m_frequency / 100;
+    uint32_t encodedFrequency = m_frequencyHz / 100;
     // Frequency is in little endian (lsb -> msb)
     start.WriteU8(encodedFrequency);       // Least significant byte
     start.WriteU8(encodedFrequency >> 8);  // Middle byte
@@ -771,7 +772,7 @@ NewChannelReq::Deserialize(Buffer::Iterator& start)
     encodedFrequency += start.ReadU8();       // Least significant byte
     encodedFrequency += start.ReadU8() << 8;  // Middle byte
     encodedFrequency += start.ReadU8() << 16; // Most significant byte
-    m_frequency = encodedFrequency * 100;
+    m_frequencyHz = encodedFrequency * 100;
     uint8_t dataRateByte = start.ReadU8();
     m_maxDataRate = dataRateByte >> 4;
     m_minDataRate = dataRateByte & 0xf;
@@ -784,7 +785,7 @@ NewChannelReq::Print(std::ostream& os) const
     NS_LOG_FUNCTION(this);
     os << "NewChannelReq(";
     os << "ChIndex=" << unsigned(m_chIndex);
-    os << ", Frequency=" << uint32_t(m_frequency);
+    os << ", Frequency=" << uint32_t(m_frequencyHz);
     os << ", MaxDR=" << unsigned(m_maxDataRate);
     os << ", MinDR=" << unsigned(m_minDataRate);
     os << ")";
@@ -801,7 +802,7 @@ double
 NewChannelReq::GetFrequency() const
 {
     NS_LOG_FUNCTION(this);
-    return m_frequency;
+    return m_frequencyHz;
 }
 
 uint8_t

--- a/model/mac-command.h
+++ b/model/mac-command.h
@@ -398,9 +398,9 @@ class RxParamSetupReq : public MacCommand
      *
      * @param rx1DrOffset The data rate offset to use for the first receive window.
      * @param rx2DataRate The data rate to use for the second receive window.
-     * @param frequency The frequency in Hz to use for the second receive window.
+     * @param frequencyHz The frequency in Hz to use for the second receive window.
      */
-    RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequency);
+    RxParamSetupReq(uint8_t rx1DrOffset, uint8_t rx2DataRate, double frequencyHz);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -430,7 +430,7 @@ class RxParamSetupReq : public MacCommand
   private:
     uint8_t m_rx1DrOffset; //!< The RX1DROffset field
     uint8_t m_rx2DataRate; //!< The RX2DataRate field
-    double m_frequency;    //!< The Frequency field, _in Hz_
+    double m_frequencyHz;  //!< The Frequency field, _in Hz_
 };
 
 /**
@@ -562,11 +562,11 @@ class NewChannelReq : public MacCommand
      * Constructor providing initialization of all parameters.
      *
      * @param chIndex The index of the channel this command wants to operate on.
-     * @param frequency The new frequency for this channel in Hz.
+     * @param frequencyHz The new frequency for this channel in Hz.
      * @param minDataRate The minimum data rate allowed on this channel.
      * @param maxDataRate The maximum data rate allowed on this channel.
      */
-    NewChannelReq(uint8_t chIndex, double frequency, uint8_t minDataRate, uint8_t maxDataRate);
+    NewChannelReq(uint8_t chIndex, double frequencyHz, uint8_t minDataRate, uint8_t maxDataRate);
 
     void Serialize(Buffer::Iterator& start) const override;
     uint8_t Deserialize(Buffer::Iterator& start) override;
@@ -599,7 +599,7 @@ class NewChannelReq : public MacCommand
 
   private:
     uint8_t m_chIndex;     //!< The ChIndex field
-    double m_frequency;    //!< The Frequency field, in Hz
+    double m_frequencyHz;  //!< The Frequency field, in Hz
     uint8_t m_minDataRate; //!< The MinDR field
     uint8_t m_maxDataRate; //!< The MaxDR field
 };

--- a/model/periodic-sender.cc
+++ b/model/periodic-sender.cc
@@ -33,7 +33,7 @@ PeriodicSender::GetTypeId()
                             .SetGroupName("lorawan")
                             .AddAttribute("Interval",
                                           "The interval between packet sends of this app",
-                                          TimeValue(Seconds(0)),
+                                          TimeValue(Time(0)),
                                           MakeTimeAccessor(&PeriodicSender::GetInterval,
                                                            &PeriodicSender::SetInterval),
                                           MakeTimeChecker());
@@ -134,8 +134,8 @@ PeriodicSender::StartApplication()
 
     // Schedule the next SendPacket event
     Simulator::Cancel(m_sendEvent);
-    NS_LOG_DEBUG("Starting up application with a first event with a " << m_initialDelay.GetSeconds()
-                                                                      << " seconds delay");
+    NS_LOG_DEBUG("Starting up application with a first event with a " << m_initialDelay.As(Time::S)
+                                                                      << " delay");
     m_sendEvent = Simulator::Schedule(m_initialDelay, &PeriodicSender::SendPacket, this);
     NS_LOG_DEBUG("Event Id: " << m_sendEvent.GetUid());
 }

--- a/model/simple-end-device-lora-phy.cc
+++ b/model/simple-end-device-lora-phy.cc
@@ -150,7 +150,7 @@ SimpleEndDeviceLoraPhy::StartReceive(Ptr<Packet> packet,
         if (!IsOnFrequency(frequencyMHz))
         {
             NS_LOG_INFO("Packet lost because it's on frequency "
-                        << frequencyMHz << " MHz and we are listening at " << m_frequency
+                        << frequencyMHz << " MHz and we are listening at " << m_frequencyMHz
                         << " MHz");
 
             // Fire the trace source for this event.

--- a/model/simple-end-device-lora-phy.cc
+++ b/model/simple-end-device-lora-phy.cc
@@ -216,8 +216,7 @@ SimpleEndDeviceLoraPhy::StartReceive(Ptr<Packet> packet,
             SwitchToRx();
 
             // Schedule the end of the reception of the packet
-            NS_LOG_INFO("Scheduling reception of a packet. End in " << duration.GetSeconds()
-                                                                    << " seconds");
+            NS_LOG_INFO("Scheduling reception of a packet. End in " << duration.As(Time::S));
 
             Simulator::Schedule(duration, &LoraPhy::EndReceive, this, packet, event);
 

--- a/model/sub-band.cc
+++ b/model/sub-band.cc
@@ -15,29 +15,29 @@ namespace lorawan
 
 NS_LOG_COMPONENT_DEFINE("SubBand");
 
-SubBand::SubBand(double firstFrequency,
-                 double lastFrequency,
+SubBand::SubBand(double firstFrequencyMHz,
+                 double lastFrequencyMHz,
                  double dutyCycle,
                  double maxTxPowerDbm)
-    : m_firstFrequency(firstFrequency),
-      m_lastFrequency(lastFrequency),
+    : m_firstFrequencyMHz(firstFrequencyMHz),
+      m_lastFrequencyMHz(lastFrequencyMHz),
       m_dutyCycle(dutyCycle),
       m_nextTransmissionTime(Time(0)),
       m_maxTxPowerDbm(maxTxPowerDbm)
 {
-    NS_LOG_FUNCTION(this << firstFrequency << lastFrequency << dutyCycle << maxTxPowerDbm);
+    NS_LOG_FUNCTION(this << firstFrequencyMHz << lastFrequencyMHz << dutyCycle << maxTxPowerDbm);
 }
 
 double
 SubBand::GetFirstFrequency() const
 {
-    return m_firstFrequency;
+    return m_firstFrequencyMHz;
 }
 
 double
 SubBand::GetLastFrequency() const
 {
-    return m_lastFrequency;
+    return m_lastFrequencyMHz;
 }
 
 double
@@ -47,9 +47,9 @@ SubBand::GetDutyCycle() const
 }
 
 bool
-SubBand::Contains(double frequency) const
+SubBand::Contains(double frequencyMHz) const
 {
-    return (frequency > m_firstFrequency) && (frequency < m_lastFrequency);
+    return (frequencyMHz > m_firstFrequencyMHz) && (frequencyMHz < m_lastFrequencyMHz);
 }
 
 bool

--- a/model/sub-band.h
+++ b/model/sub-band.h
@@ -31,12 +31,15 @@ class SubBand : public SimpleRefCount<SubBand>
     /**
      * Create a new SubBand by specifying all of its properties.
      *
-     * @param firstFrequency The SubBand's lowest frequency [MHz].
-     * @param lastFrequency The SubBand's highest frequency [MHz].
+     * @param firstFrequencyMHz The SubBand's lowest frequency [MHz].
+     * @param lastFrequencyMHz The SubBand's highest frequency [MHz].
      * @param dutyCycle The duty cycle (as a fraction) allowed on this SubBand.
      * @param maxTxPowerDbm The maximum transmission power [dBm] allowed on this SubBand.
      */
-    SubBand(double firstFrequency, double lastFrequency, double dutyCycle, double maxTxPowerDbm);
+    SubBand(double firstFrequencyMHz,
+            double lastFrequencyMHz,
+            double dutyCycle,
+            double maxTxPowerDbm);
 
     /**
      * Get the lowest frequency of the SubBand.
@@ -83,11 +86,11 @@ class SubBand : public SimpleRefCount<SubBand>
     /**
      * Return whether or not a frequency belongs to this SubBand.
      *
-     * @param frequency The frequency [MHz] we want to test against the current subband.
+     * @param frequencyMHz The frequency [MHz] we want to test against the current subband.
      * @return True if the frequency is between firstFrequency and lastFrequency,
      * false otherwise.
      */
-    bool Contains(double frequency) const;
+    bool Contains(double frequencyMHz) const;
 
     /**
      * Return whether or not a channel belongs to this SubBand.
@@ -113,8 +116,8 @@ class SubBand : public SimpleRefCount<SubBand>
     double GetMaxTxPowerDbm() const;
 
   private:
-    double m_firstFrequency;     //!< Starting frequency of the subband, in MHz
-    double m_lastFrequency;      //!< Ending frequency of the subband, in MHz
+    double m_firstFrequencyMHz;  //!< Starting frequency of the subband, in MHz
+    double m_lastFrequencyMHz;   //!< Ending frequency of the subband, in MHz
     double m_dutyCycle;          //!< The duty cycle that needs to be enforced on this subband
     Time m_nextTransmissionTime; //!< The next time a transmission will be allowed in this subband
     double m_maxTxPowerDbm; //!< The maximum transmission power that is admitted on this subband

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -955,20 +955,20 @@ LogicalLoraChannelTest::DoRun()
     channelHelper->AddEvent(Seconds(2), channel1);
     Time expectedTimeOff = Seconds(2 / 0.01);
 
-    // Waiting time is computed correctly
-    NS_TEST_EXPECT_MSG_EQ(channelHelper->GetWaitingTime(channel1),
+    // Wait time is computed correctly
+    NS_TEST_EXPECT_MSG_EQ(channelHelper->GetWaitTime(channel1),
                           expectedTimeOff,
-                          "Waiting time doesn't behave as expected");
+                          "Wait time doesn't behave as expected");
 
     // Duty Cycle involves the whole SubBand, not just a channel
-    NS_TEST_EXPECT_MSG_EQ(channelHelper->GetWaitingTime(channel2),
+    NS_TEST_EXPECT_MSG_EQ(channelHelper->GetWaitTime(channel2),
                           expectedTimeOff,
-                          "Waiting time doesn't behave as expected");
+                          "Wait time doesn't behave as expected");
 
     // Other bands are not affected by this transmission
-    NS_TEST_EXPECT_MSG_EQ(channelHelper->GetWaitingTime(channel3),
+    NS_TEST_EXPECT_MSG_EQ(channelHelper->GetWaitTime(channel3),
                           Time(0),
-                          "Waiting time affects other subbands");
+                          "Wait time affects other subbands");
 }
 
 /**

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -1679,7 +1679,7 @@ MacCommandTest::Reset()
     macHelper.SetRegion(LorawanMacHelper::EU);
     macHelper.SetDeviceType(LorawanMacHelper::ED_A);
     /// @todo Create should not require a node in input.
-    m_mac = DynamicCast<ClassAEndDeviceLorawanMac>(macHelper.Create(nullptr, nullptr));
+    m_mac = DynamicCast<ClassAEndDeviceLorawanMac>(macHelper.Install(nullptr, nullptr));
     NS_TEST_EXPECT_MSG_NE(m_mac, nullptr, "Failed to initialize MAC layer object.");
     auto phy = CreateObject<SimpleEndDeviceLoraPhy>();
     phy->SetChannel(CreateObject<LoraChannel>());

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -1721,7 +1721,7 @@ MacCommandTest::DoRun()
         NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetDataRate()),
                               unsigned(dataRate),
                               "m_dataRate does not match DataRate field of LinkAdrReq");
-        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPowerDbm(),
                               14 - txPower * 2,
                               "m_txPowerDbm does not match txPower field of LinkAdrReq");
         NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetMaxNumberOfTransmissions()),
@@ -1756,7 +1756,7 @@ MacCommandTest::DoRun()
         NS_TEST_EXPECT_MSG_NE(unsigned(m_mac->GetDataRate()),
                               unsigned(dataRate),
                               "m_dataRate expected to differ from DataRate field of LinkAdrReq");
-        NS_TEST_EXPECT_MSG_NE(m_mac->GetTransmissionPower(),
+        NS_TEST_EXPECT_MSG_NE(m_mac->GetTransmissionPowerDbm(),
                               14 - txPower * 2,
                               "m_txPowerDbm expected to not match txPower field of LinkAdrReq");
         NS_TEST_EXPECT_MSG_NE(unsigned(m_mac->GetMaxNumberOfTransmissions()),
@@ -1790,7 +1790,7 @@ MacCommandTest::DoRun()
         NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetDataRate()),
                               0,
                               "m_dataRate expected to be default value");
-        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPowerDbm(),
                               14,
                               "m_txPowerDbm expected to be default value");
         NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetMaxNumberOfTransmissions()),
@@ -1824,7 +1824,7 @@ MacCommandTest::DoRun()
         NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetDataRate()),
                               0,
                               "m_dataRate expected to be default value");
-        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPowerDbm(),
                               14,
                               "m_txPowerDbm expected to be default value");
         NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetMaxNumberOfTransmissions()),
@@ -1856,7 +1856,7 @@ MacCommandTest::DoRun()
         uint8_t nbTrans = 0;    // restore default 1
         // Set device params to values different from default
         m_mac->SetDataRate(3);
-        m_mac->SetTransmissionPower(12);
+        m_mac->SetTransmissionPowerDbm(12);
         m_mac->SetMaxNumberOfTransmissions(15);
         auto channels = m_mac->GetLogicalLoraChannelHelper()->GetRawChannelArray();
         channels.at(0)->DisableForUplink();
@@ -1864,9 +1864,9 @@ MacCommandTest::DoRun()
         NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetDataRate()),
                               3,
                               "m_dataRate expected to be default value");
-        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPower(),
+        NS_TEST_EXPECT_MSG_EQ(m_mac->GetTransmissionPowerDbm(),
                               12,
-                              "m_txPower expected to be default value");
+                              "m_txPowerDbm expected to be default value");
         NS_TEST_EXPECT_MSG_EQ(unsigned(m_mac->GetMaxNumberOfTransmissions()),
                               1,
                               "m_nbTrans expected to be default value");

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -59,36 +59,36 @@ InterferenceTest::DoRun()
 
     LoraInterferenceHelper interferenceHelper;
 
-    double frequency = 868.1;
-    double differentFrequency = 868.3;
+    double frequencyMHz = 868.1;
+    double differentFrequencyMHz = 868.3;
 
     Ptr<LoraInterferenceHelper::Event> event;
     Ptr<LoraInterferenceHelper::Event> event1;
 
     // Test overlap duration
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    event1 = interferenceHelper.Add(Seconds(1), 14, 12, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    event1 = interferenceHelper.Add(Seconds(1), 14, 12, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(1),
                           "Overlap computation didn't give the expected result");
     interferenceHelper.ClearAllEvents();
 
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    event1 = interferenceHelper.Add(Seconds(1.5), 14, 12, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    event1 = interferenceHelper.Add(Seconds(1.5), 14, 12, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(1.5),
                           "Overlap computation didn't give the expected result");
     interferenceHelper.ClearAllEvents();
 
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    event1 = interferenceHelper.Add(Seconds(3), 14, 12, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    event1 = interferenceHelper.Add(Seconds(3), 14, 12, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.GetOverlapTime(event, event1),
                           Seconds(2),
                           "Overlap computation didn't give the expected result");
     interferenceHelper.ClearAllEvents();
 
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    event1 = interferenceHelper.Add(Seconds(2), 14, 12, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    event1 = interferenceHelper.Add(Seconds(2), 14, 12, nullptr, frequencyMHz);
     // Because of some strange behavior, this test would get stuck if we used the same syntax of the
     // previous ones. This works instead.
     bool retval = interferenceHelper.GetOverlapTime(event, event1) == Seconds(2);
@@ -96,32 +96,32 @@ InterferenceTest::DoRun()
     interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet survives
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14, 12, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14, 12, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
     interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet survives
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 - 7, 7, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 - 7, 7, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
     interferenceHelper.ClearAllEvents();
 
     // Perfect overlap, packet destroyed
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 - 6, 7, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 - 6, 7, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           7,
                           "Packet was not destroyed by interference as expected");
     interferenceHelper.ClearAllEvents();
 
     // Partial overlap, packet survives
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(1), 14 - 6, 7, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(1), 14 - 6, 7, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
@@ -130,8 +130,8 @@ InterferenceTest::DoRun()
     // Different frequencys
     // Packet would be destroyed if they were on the same frequency, but survives
     // since they are on different frequencies
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14, 7, nullptr, differentFrequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14, 7, nullptr, differentFrequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
@@ -140,8 +140,8 @@ InterferenceTest::DoRun()
     // Different SFs
     // Packet would be destroyed if they both were SF7, but survives thanks to spreading factor
     // semi-orthogonality
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");
@@ -149,16 +149,16 @@ InterferenceTest::DoRun()
 
     // Spreading factor imperfect orthogonality
     // Different SFs are orthogonal only up to a point
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 17, 8, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 17, 8, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           8,
                           "Packet was not destroyed by interference as expected");
     interferenceHelper.ClearAllEvents();
 
     // If a more 'distant' spreading factor is used, isolation gets better
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 17, 10, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 17, 10, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet was destroyed by interference while it should have survived");
@@ -166,10 +166,10 @@ InterferenceTest::DoRun()
 
     // Cumulative interference
     // Same spreading factor interference is cumulative
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           8,
                           "Packet was not destroyed by interference as expected");
@@ -177,10 +177,10 @@ InterferenceTest::DoRun()
 
     // Cumulative interference
     // Interference is not cumulative between different SFs
-    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 9, nullptr, frequency);
-    interferenceHelper.Add(Seconds(2), 14 + 16, 10, nullptr, frequency);
+    event = interferenceHelper.Add(Seconds(2), 14, 7, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 8, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 9, nullptr, frequencyMHz);
+    interferenceHelper.Add(Seconds(2), 14 + 16, 10, nullptr, frequencyMHz);
     NS_TEST_EXPECT_MSG_EQ(interferenceHelper.IsDestroyedByInterference(event),
                           0,
                           "Packet did not survive interference as expected");


### PR DESCRIPTION
This pull request is a follow-up to PR #184 with additional minor changes initially proposed in #183. It introduces the following changes by commit message (additional annotations in _italics_):

- _Uniformize all_ Tx power dBm values to double + annotate dB/dBm in names
- Refactor DB to Db everywhere for consistency
- Annotate frequency variables with MHz/Hz
- Refactor Create to Install in LoraPhyHelper and LorawanMacHelper to avoid name collision with ns3::Create
- Evaluate null Ptr in return statements as indicated by the Ptr class documentation
- Refactor waitingTime to waitTime (English proofing)
- Time-related code improvements 
  - better time printing using Time::As()
  - prefer more general Time(0) instead Seconds(0) or others when indicating zero time
  - use time methods Time::IsZero(), Time::IsPositive(), etc. when working with time
  - prefer shorter Now() in place of Simulator::Now()
 