### PR TITLE
Align use of Create() vs. CreateObject() for SimpleRefCount vs. Object classes

### DIFF
--- a/model/gateway-status.cc
+++ b/model/gateway-status.cc
@@ -20,8 +20,10 @@ NS_LOG_COMPONENT_DEFINE("GatewayStatus");
 TypeId
 GatewayStatus::GetTypeId()
 {
-    static TypeId tid =
-        TypeId("ns3::GatewayStatus").AddConstructor<GatewayStatus>().SetGroupName("lorawan");
+    static TypeId tid = TypeId("ns3::GatewayStatus")
+                            .SetParent<Object>()
+                            .AddConstructor<GatewayStatus>()
+                            .SetGroupName("lorawan");
     return tid;
 }
 

--- a/model/mac-command.cc
+++ b/model/mac-command.cc
@@ -20,15 +20,6 @@ namespace lorawan
 
 NS_LOG_COMPONENT_DEFINE("MacCommand");
 
-NS_OBJECT_ENSURE_REGISTERED(MacCommand);
-
-TypeId
-MacCommand::GetTypeId()
-{
-    static TypeId tid = TypeId("ns3::MacCommand").SetParent<Object>().SetGroupName("lorawan");
-    return tid;
-}
-
 MacCommand::MacCommand()
 {
     NS_LOG_FUNCTION(this);
@@ -36,7 +27,6 @@ MacCommand::MacCommand()
 
 MacCommand::~MacCommand()
 {
-    NS_LOG_FUNCTION(this);
 }
 
 enum MacCommandType

--- a/model/mac-command.h
+++ b/model/mac-command.h
@@ -11,7 +11,7 @@
 
 #include "ns3/buffer.h"
 #include "ns3/nstime.h"
-#include "ns3/object.h"
+#include "ns3/simple-ref-count.h"
 
 namespace ns3
 {
@@ -53,17 +53,11 @@ enum MacCommandType
  * common features are supposed to be defined in detail by child classes, based
  * on that MAC command's attributes and structure.
  */
-class MacCommand : public Object
+class MacCommand : public SimpleRefCount<MacCommand>
 {
   public:
-    /**
-     *  Register this type.
-     *  @return The object TypeId.
-     */
-    static TypeId GetTypeId();
-
-    MacCommand();           //!< Default constructor
-    ~MacCommand() override; //!< Destructor
+    MacCommand();          //!< Default constructor
+    virtual ~MacCommand(); //!< Destructor
 
     /**
      * Serialize the contents of this MAC command into a buffer, according to the

--- a/model/network-server.cc
+++ b/model/network-server.cc
@@ -47,9 +47,9 @@ NetworkServer::GetTypeId()
 }
 
 NetworkServer::NetworkServer()
-    : m_status(Create<NetworkStatus>()),
-      m_controller(Create<NetworkController>(m_status)),
-      m_scheduler(Create<NetworkScheduler>(m_status, m_controller))
+    : m_status(CreateObject<NetworkStatus>()),
+      m_controller(CreateObject<NetworkController>(m_status)),
+      m_scheduler(CreateObject<NetworkScheduler>(m_status, m_controller))
 {
     NS_LOG_FUNCTION_NOARGS();
 }
@@ -97,7 +97,7 @@ NetworkServer::AddGateway(Ptr<Node> gateway, Ptr<NetDevice> netDevice)
     Address gatewayAddress = p2pNetDevice->GetAddress();
 
     // Create new gatewayStatus
-    Ptr<GatewayStatus> gwStatus = Create<GatewayStatus>(gatewayAddress, netDevice, gwMac);
+    Ptr<GatewayStatus> gwStatus = CreateObject<GatewayStatus>(gatewayAddress, netDevice, gwMac);
 
     m_status->AddGateway(gatewayAddress, gwStatus);
 }


### PR DESCRIPTION
This pull request is meant to fix issue #191.
