### PR TITLE
Add basic PCAP export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(source_files
     model/lora-device-address.cc
     model/lora-device-address-generator.cc
     model/lora-tag.cc
+    model/loratap-header.cc
     model/network-server.cc
     model/network-status.cc
     model/network-controller.cc
@@ -75,6 +76,7 @@ set(header_files
     model/lora-device-address.h
     model/lora-device-address-generator.h
     model/lora-tag.h
+    model/loratap-header.h
     model/network-server.h
     model/network-status.h
     model/network-controller.h
@@ -113,4 +115,5 @@ build_lib(
     test/network-status-test-suite.cc
     test/network-scheduler-test-suite.cc
     test/network-server-test-suite.cc
+    test/pcap-serialization-test-suite.cc
 )

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -50,12 +50,13 @@ static double simulationTimeSeconds = 600; //!< Scenario duration (s) in simulat
 
 // Channel model
 static bool realisticChannelModel = false; //!< Whether to use a more realistic channel model with
-                                    //!< Buildings and correlated shadowing
+                                           //!< Buildings and correlated shadowing
 
 static int appPeriodSeconds = 600; //!< Duration (s) of the inter-transmission time of end devices
 
 // Output control
 static bool printBuildingInfo = true; //!< Whether to print building information
+static bool pcapExport = false;       //!< Whether to dump PCAP files
 
 int
 main(int argc, char* argv[])
@@ -71,6 +72,7 @@ main(int argc, char* argv[])
                  "The period in seconds to be used by periodically transmitting applications",
                  appPeriodSeconds);
     cmd.AddValue("print", "Whether or not to print building information", printBuildingInfo);
+    cmd.AddValue("pcap", "Whether to export traffic as PCAP file", pcapExport);
     cmd.Parse(argc, argv);
 
     // Set up logging
@@ -334,6 +336,11 @@ main(int argc, char* argv[])
 
     // Create a forwarder for each gateway
     forHelper.Install(gateways);
+
+    if (pcapExport)
+    {
+        helper.EnablePcap("complete-network-example", gateways, true);
+    }
 
     ////////////////
     // Simulation //

--- a/examples/complete-network-example.cc
+++ b/examples/complete-network-example.cc
@@ -35,7 +35,6 @@
 #include "ns3/random-variable-stream.h"
 #include "ns3/simulator.h"
 
-#include <algorithm>
 #include <ctime>
 
 using namespace ns3;
@@ -44,19 +43,19 @@ using namespace lorawan;
 NS_LOG_COMPONENT_DEFINE("ComplexLorawanNetworkExample");
 
 // Network settings
-int nDevices = 200;                 //!< Number of end device nodes to create
-int nGateways = 1;                  //!< Number of gateway nodes to create
-double radiusMeters = 6400;         //!< Radius (m) of the deployment
-double simulationTimeSeconds = 600; //!< Scenario duration (s) in simulated time
+static int nDevices = 200;                 //!< Number of end device nodes to create
+static int nGateways = 1;                  //!< Number of gateway nodes to create
+static double radiusMeters = 6400;         //!< Radius (m) of the deployment
+static double simulationTimeSeconds = 600; //!< Scenario duration (s) in simulated time
 
 // Channel model
-bool realisticChannelModel = false; //!< Whether to use a more realistic channel model with
+static bool realisticChannelModel = false; //!< Whether to use a more realistic channel model with
                                     //!< Buildings and correlated shadowing
 
-int appPeriodSeconds = 600; //!< Duration (s) of the inter-transmission time of end devices
+static int appPeriodSeconds = 600; //!< Duration (s) of the inter-transmission time of end devices
 
 // Output control
-bool printBuildingInfo = true; //!< Whether to print building information
+static bool printBuildingInfo = true; //!< Whether to print building information
 
 int
 main(int argc, char* argv[])

--- a/examples/network-server-example.cc
+++ b/examples/network-server-example.cc
@@ -40,9 +40,11 @@ int
 main(int argc, char* argv[])
 {
     bool verbose = false;
+    bool pcapExport = false;
 
     CommandLine cmd(__FILE__);
     cmd.AddValue("verbose", "Whether to print output or not", verbose);
+    cmd.AddValue("pcap", "Whether to export traffic as PCAP file", pcapExport);
     cmd.Parse(argc, argv);
 
     // Logging
@@ -192,6 +194,11 @@ main(int argc, char* argv[])
     // Install the Forwarder application on the gateways
     ForwarderHelper forwarderHelper;
     forwarderHelper.Install(gateways);
+
+    if (pcapExport)
+    {
+        helper.EnablePcap("network-server-example", gateways, true);
+    }
 
     // Start simulation
     Simulator::Stop(Seconds(800));

--- a/helper/lora-helper.cc
+++ b/helper/lora-helper.cc
@@ -9,6 +9,7 @@
 #include "lora-helper.h"
 
 #include "ns3/log.h"
+#include "ns3/loratap-header.h"
 
 #include <fstream>
 
@@ -18,6 +19,21 @@ namespace lorawan
 {
 
 NS_LOG_COMPONENT_DEFINE("LoraHelper");
+
+/**
+ * @brief Write a packet in a PCAP file
+ * @param file the output file
+ * @param packet the packet
+ */
+static void
+PcapSniffLora(Ptr<PcapFileWrapper> file, Ptr<const Packet> packet, uint32_t)
+{
+    Ptr<Packet> p = packet->Copy();
+    LoraTag tag;
+    p->RemovePacketTag(tag);
+    p->AddHeader(LoraTapHeader(tag));
+    file->Write(Simulator::Now(), p);
+}
 
 LoraHelper::LoraHelper()
     : m_lastPhyPerformanceUpdate(Time(0)),
@@ -321,6 +337,47 @@ LoraHelper::DoPrintSimulationTime(Time interval)
               << std::endl;
     m_oldtime = std::time(nullptr);
     Simulator::Schedule(interval, &LoraHelper::DoPrintSimulationTime, this, interval);
+}
+
+void
+LoraHelper::EnablePcapInternal(std::string prefix,
+                               Ptr<NetDevice> netdev,
+                               bool promiscuous,
+                               bool explicitFilename)
+{
+    NS_LOG_FUNCTION(this << prefix << netdev << promiscuous << explicitFilename);
+
+    Ptr<LoraNetDevice> device = netdev->GetObject<LoraNetDevice>();
+
+    if (!device)
+    {
+        NS_LOG_INFO("LoraHelper::EnablePcapInternal: Cannot enable PCAP for "
+                    << netdev << ": not a LoraNetDev");
+        return;
+    }
+
+    PcapHelper pcapHelper;
+
+    std::string filename;
+    if (explicitFilename)
+    {
+        filename = prefix;
+    }
+    else
+    {
+        filename = pcapHelper.GetFilenameFromDevice(prefix, device);
+    }
+
+    Ptr<PcapFileWrapper> file =
+        pcapHelper.CreateFile(filename, std::ios::out, PcapHelper::DLT_LORATAP);
+
+    if (!promiscuous)
+    {
+        NS_LOG_WARN("LoraHelper::EnablePcapInternal: Tracing non-promiscuous is not supperted.");
+    }
+    device->GetPhy()->TraceConnectWithoutContext("ReceivedPacket",
+                                                 MakeBoundCallback(&PcapSniffLora, file));
+    device->GetPhy()->TraceConnectWithoutContext("StartSending", MakeBoundCallback(PcapSniffLora, file));
 }
 
 } // namespace lorawan

--- a/helper/lora-helper.h
+++ b/helper/lora-helper.h
@@ -17,6 +17,7 @@
 #include "ns3/net-device-container.h"
 #include "ns3/net-device.h"
 #include "ns3/node-container.h"
+#include "ns3/trace-helper.h"
 
 #include <ctime>
 
@@ -33,7 +34,7 @@ namespace lorawan
  * This class can help create a large set of similar LoraNetDevice objects and
  * configure a large set of their attributes during creation.
  */
-class LoraHelper
+class LoraHelper : public PcapHelperForDevice
 {
   public:
     LoraHelper();          //!< Default constructor
@@ -171,6 +172,22 @@ class LoraHelper
      * @param interval The delay for next printing.
      */
     void DoPrintSimulationTime(Time interval);
+
+    /**
+     * @brief Enable pcap output on the indicated net device.
+     *
+     * NetDevice-specific implementation mechanism for hooking the trace and
+     * writing to the trace file.
+     *
+     * @param prefix Filename prefix to use for pcap files.
+     * @param netdev Net device for which you want to enable tracing.
+     * @param promiscuous If true capture all possible packets available at the device.
+     * @param explicitFilename Treat the prefix as an explicit filename if true
+     */
+    void EnablePcapInternal(std::string prefix,
+                            Ptr<NetDevice> netdev,
+                            bool promiscuous,
+                            bool explicitFilename) override;
 
     Time m_lastPhyPerformanceUpdate;    //!< Timestamp of the last PHY performance update
     Time m_lastGlobalPerformanceUpdate; //!< Timestamp of the last global performance update

--- a/model/lora-tag.cc
+++ b/model/lora-tag.cc
@@ -18,6 +18,8 @@ namespace lorawan
 
 NS_OBJECT_ENSURE_REGISTERED(LoraTag);
 
+static const uint8_t SYNC_WORD_LORAWAN = 0x34;
+
 TypeId
 LoraTag::GetTypeId()
 {
@@ -34,10 +36,13 @@ LoraTag::GetInstanceTypeId() const
 
 LoraTag::LoraTag(uint8_t sf, uint8_t destroyedBy)
     : m_sf(sf),
+      m_sync(SYNC_WORD_LORAWAN),
       m_destroyedBy(destroyedBy),
       m_receivePower(0),
       m_dataRate(0),
-      m_frequencyHz(0)
+      m_frequencyHz(0),
+      m_bandwidthHz(125000),
+      m_snrDb(0.0)
 {
 }
 
@@ -48,29 +53,37 @@ LoraTag::~LoraTag()
 uint32_t
 LoraTag::GetSerializedSize() const
 {
-    // Each datum about a spreading factor is 1 byte + receivePower (the size of a double) +
-    // frequency (4 bytes)
-    return 3 + sizeof(double) + 4;
+    // 4 * uint8_t: (m_sf, m_sync, m_destroyedBy, m_dataRate)
+    // 2 * uint32_t: (m_frequencyHz, m_bandwidthHz)
+    // 2 * double: (m_receivePower, m_snrDb)
+    return 4 * sizeof(uint8_t) + 2 * sizeof(uint32_t) + 2 * sizeof(double);
 }
 
 void
 LoraTag::Serialize(TagBuffer i) const
 {
     i.WriteU8(m_sf);
+    i.WriteU8(m_sync);
     i.WriteU8(m_destroyedBy);
     i.WriteDouble(m_receivePower);
     i.WriteU8(m_dataRate);
     i.WriteU32(m_frequencyHz);
+    i.WriteU32(m_bandwidthHz);
+    i.WriteDouble(m_snrDb);
+
 }
 
 void
 LoraTag::Deserialize(TagBuffer i)
 {
     m_sf = i.ReadU8();
+    m_sync = i.ReadU8();
     m_destroyedBy = i.ReadU8();
     m_receivePower = i.ReadDouble();
     m_dataRate = i.ReadU8();
     m_frequencyHz = i.ReadU32();
+    m_bandwidthHz = i.ReadU32();
+    m_snrDb = i.ReadDouble();
 }
 
 void
@@ -125,6 +138,42 @@ uint32_t
 LoraTag::GetFrequency() const
 {
     return m_frequencyHz;
+}
+
+void
+LoraTag::SetChannelBandwidth(uint32_t bandwidthHz)
+{
+    m_bandwidthHz = bandwidthHz;
+}
+
+uint32_t
+LoraTag::GetChannelBandwidth() const
+{
+    return m_bandwidthHz;
+}
+
+void
+LoraTag::SetSyncWord(uint8_t syncWord)
+{
+    m_sync = syncWord;
+}
+
+uint8_t
+LoraTag::GetSyncWord() const
+{
+    return m_sync;
+}
+
+void
+LoraTag::SetSignalToNoise(double snrDb)
+{
+    m_snrDb = snrDb;
+}
+
+double
+LoraTag::GetSignalToNoise() const
+{
+    return m_snrDb;
 }
 
 uint8_t

--- a/model/lora-tag.h
+++ b/model/lora-tag.h
@@ -69,6 +69,19 @@ class LoraTag : public Tag
     double GetReceivePower() const;
 
     /**
+     * Set the signal to noise ratio [dB]
+     * @param snrDb The signal to noise ration in dB
+     */
+    void SetSignalToNoise(double snrDb);
+
+    /**
+     * Get the signal to noise ratio [dB] of this packet
+     *
+     * @return The signal to noise ratio in dB.
+     */
+    double GetSignalToNoise() const;
+
+    /**
      * Set which Spreading Factor this packet was transmitted with.
      *
      * @param sf The Spreading Factor.
@@ -116,6 +129,20 @@ class LoraTag : public Tag
     uint32_t GetFrequency() const;
 
     /**
+     * Set the bandwidth [Hz] of the channel the packet is send on.
+     *
+     * @param bandwidthHz The bandwidth [Hz] of the used channel.
+     */
+    void SetChannelBandwidth(uint32_t bandwidthHz);
+
+    /**
+     * Get the bandwidth [Hz] of the channel the packet is transmitted on.
+     *
+     * @return The bandwidth [Hz] of the channel the packet is transmitted on.
+     */
+    uint32_t GetChannelBandwidth() const;
+
+    /**
      * Get the data rate for this packet.
      *
      * @return The data rate that needs to be employed for this packet.
@@ -129,12 +156,25 @@ class LoraTag : public Tag
      */
     void SetDataRate(uint8_t dataRate);
 
+    /**
+     * Set the sync word of this packet.
+     */
+    void SetSyncWord(uint8_t syncWord);
+
+    /**
+     * Get the sync word of this packet.
+     */
+    uint8_t GetSyncWord() const;
+
   private:
     uint8_t m_sf;           //!< The Spreading Factor used by the packet.
+    uint8_t m_sync;         //!< The sync word of this packet.
     uint8_t m_destroyedBy;  //!< The Spreading Factor that destroyed the packet.
     double m_receivePower;  //!< The reception power of this packet.
     uint8_t m_dataRate;     //!< The data rate that needs to be used to send this packet.
     uint32_t m_frequencyHz; //!< The frequency [Hz] of this packet
+    uint32_t m_bandwidthHz; //!< The bandwidth [Hz] of the channel this packet is on.
+    double m_snrDb;         //!< The signal to noise ratio [dB] of this packet.
 };
 } // namespace lorawan
 } // namespace ns3

--- a/model/loratap-header.cc
+++ b/model/loratap-header.cc
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2025 ML!PA Consulting GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Author: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#include "loratap-header.h"
+
+#include "ns3/assert.h"
+#include "ns3/log.h"
+
+#include <cmath>
+
+namespace ns3
+{
+namespace lorawan
+{
+
+NS_LOG_COMPONENT_DEFINE("LoraTapHeader");
+
+static const uint8_t RSSI_NOT_SPECIFIED = 0xff;
+// lowest RSSI value that can be encoded
+static const int16_t RSSI_FLOOR = -139;
+static const uint8_t SYNC_LORAWAN = 0x34;
+static const uint8_t LORATAP_VERSION = 0;
+// Bandwidth resolution is in steps of 125 kHz
+const uint32_t BANDWIDTH_RESOLUTION = 125000;
+// See ASCI packet diagram in header: Version 0 is a fixed length header of
+// 15 bytes
+static const uint16_t LORATAP_HEADER_LENGTH = 15;
+
+// Initialization list
+LoraTapHeader::LoraTapHeader()
+    : m_frequencyHz(0),
+      m_bandwidthHz(0),
+      m_spreadingFactor(0),
+      m_rssiPkt(NAN),
+      m_rssiMax(RSSI_NOT_SPECIFIED),
+      m_rssiCurrent(RSSI_NOT_SPECIFIED),
+      m_snr(0),
+      m_sync(SYNC_LORAWAN)
+{
+}
+
+LoraTapHeader::LoraTapHeader(const LoraTag& tag)
+    : m_frequencyHz(tag.GetFrequency()),
+      m_spreadingFactor(tag.GetSpreadingFactor()),
+      m_rssiPkt(tag.GetReceivePower()),
+      m_rssiMax(RSSI_NOT_SPECIFIED),
+      m_rssiCurrent(RSSI_NOT_SPECIFIED),
+      m_snr(tag.GetSignalToNoise()),
+      m_sync(tag.GetSyncWord())
+{
+    SetChannelBandwidth(tag.GetChannelBandwidth());
+}
+
+LoraTapHeader::~LoraTapHeader()
+{
+}
+
+TypeId
+LoraTapHeader::GetTypeId()
+{
+    static TypeId tid = TypeId("LoraTapHeader").SetParent<Header>().AddConstructor<LoraTapHeader>();
+    return tid;
+}
+
+TypeId
+LoraTapHeader::GetInstanceTypeId() const
+{
+    return GetTypeId();
+}
+
+uint32_t
+LoraTapHeader::GetSerializedSize() const
+{
+    NS_LOG_FUNCTION(this);
+    return LORATAP_HEADER_LENGTH;
+}
+
+void
+LoraTapHeader::Serialize(Buffer::Iterator start) const
+{
+    NS_LOG_FUNCTION(this);
+
+    uint8_t rssi = ((int32_t)m_rssiPkt - RSSI_FLOOR);
+    if (m_snr < 0)
+    {
+        int32_t tmp = m_rssiPkt * 4.0;
+        tmp -= 4 * RSSI_FLOOR;
+        rssi = tmp;
+    }
+    start.WriteU8(LORATAP_VERSION);
+    start.WriteU8(0); // Padding
+    start.WriteHtonU16(LORATAP_HEADER_LENGTH);
+    start.WriteHtonU32(m_frequencyHz);
+    start.WriteU8(m_bandwidthHz);
+    start.WriteU8(m_spreadingFactor);
+    start.WriteU8(rssi);
+    start.WriteU8(m_rssiMax);
+    start.WriteU8(m_rssiCurrent);
+    start.WriteU8(m_snr);
+    start.WriteU8(m_sync);
+}
+
+uint32_t
+LoraTapHeader::Deserialize(Buffer::Iterator start)
+{
+    NS_LOG_FUNCTION(this);
+
+    NS_ASSERT(LORATAP_VERSION == start.ReadU8());
+    (void)start.ReadU8(); // Padding
+    NS_ASSERT(LORATAP_HEADER_LENGTH == start.ReadNtohU16());
+    m_frequencyHz = start.ReadNtohU32();
+    m_bandwidthHz = start.ReadU8();
+    m_spreadingFactor = start.ReadU8();
+    uint8_t rssi = start.ReadU8();
+    m_rssiMax = start.ReadU8();
+    m_rssiCurrent = start.ReadU8();
+    m_snr = start.ReadU8();
+    m_sync = start.ReadU8();
+
+    if (m_snr < 0)
+    {
+        m_rssiPkt = rssi;
+        m_rssiPkt *= 0.25;
+        m_rssiPkt += RSSI_FLOOR;
+    }
+    else
+    {
+        m_rssiPkt = (int32_t)rssi + (int32_t)RSSI_FLOOR;
+    }
+
+    return LORATAP_HEADER_LENGTH;
+}
+
+void
+LoraTapHeader::Print(std::ostream& os) const
+{
+    os << "Freq=" << GetChannelFrequency() << " Hz";
+    os << ", Bandwidth=" << GetChannelBandwidth() << " kHz";
+    os << ", SF=" << GetSpreadingFactor();
+    os << ", RSSI[PKT]=" << GetRssiPacket() << " dBm";
+    os << ", RSSI[MAX]=" << GetRssiReceiverMax() << " dBm";
+    os << ", RSSI[CUR]=" << GetRssiReceiverCurrent() << " dBm";
+    os << ", SNR=" << GetSignalToNoise() << " dB";
+    os << ", SYNC=" << GetSyncWord();
+}
+
+void
+LoraTapHeader::SetChannelFrequency(uint32_t frequencyHz)
+{
+    m_frequencyHz = frequencyHz;
+}
+
+uint32_t
+LoraTapHeader::GetChannelFrequency() const
+{
+    return m_frequencyHz;
+}
+
+void
+LoraTapHeader::SetChannelBandwidth(uint32_t bandwidthHz)
+{
+    // scientific rounding
+    m_bandwidthHz = (bandwidthHz + BANDWIDTH_RESOLUTION / 2) / BANDWIDTH_RESOLUTION;
+}
+
+uint32_t
+LoraTapHeader::GetChannelBandwidth() const
+{
+    return m_bandwidthHz * BANDWIDTH_RESOLUTION;
+}
+
+void
+LoraTapHeader::SetSpreadingFactor(uint8_t sf)
+{
+    m_spreadingFactor = sf;
+}
+
+uint8_t
+LoraTapHeader::GetSpreadingFactor() const
+{
+    return m_spreadingFactor;
+}
+
+void
+LoraTapHeader::SetRssiPacket(double rssi)
+{
+    m_rssiPkt = rssi;
+}
+
+void
+LoraTapHeader::ClearRssiPacket()
+{
+    m_rssiPkt = NAN;
+}
+
+bool
+LoraTapHeader::HasRssiPacket() const
+{
+    return !std::isnan(m_rssiPkt);
+}
+
+double
+LoraTapHeader::GetRssiPacket() const
+{
+    return m_rssiPkt;
+}
+
+void
+LoraTapHeader::SetRssiReceiverMax(double rssi)
+{
+    int32_t tmp = rssi;
+    tmp -= RSSI_FLOOR;
+    m_rssiMax = tmp;
+}
+
+void
+LoraTapHeader::ClearRssiReceiverMax()
+{
+    m_rssiMax = RSSI_NOT_SPECIFIED;
+}
+
+bool
+LoraTapHeader::HasRssiReceiverMax() const
+{
+    return m_rssiMax != RSSI_NOT_SPECIFIED;
+}
+
+double
+LoraTapHeader::GetRssiReceiverMax() const
+{
+    if (!HasRssiReceiverMax())
+    {
+        return NAN;
+    }
+
+    return (int32_t)m_rssiMax + (int32_t)RSSI_FLOOR;
+}
+
+void
+LoraTapHeader::SetRssiReceiverCurrent(double rssi)
+{
+    const double min = RSSI_FLOOR;
+    const double max = (int32_t)RSSI_FLOOR + (int32_t)UINT8_MAX;
+
+    if (rssi <= min)
+    {
+        m_rssiCurrent = 0;
+        return;
+    }
+
+    if (rssi >= max)
+    {
+        m_rssiCurrent = UINT8_MAX;
+        return;
+    }
+
+    int32_t tmp = rssi;
+    tmp -= RSSI_FLOOR;
+    m_rssiCurrent = tmp;
+}
+
+void
+LoraTapHeader::ClearRssiReceiverCurrent()
+{
+    m_rssiCurrent = RSSI_NOT_SPECIFIED;
+}
+
+bool
+LoraTapHeader::HasRssiReceiverCurrent() const
+{
+    return m_rssiCurrent != RSSI_NOT_SPECIFIED;
+}
+
+double
+LoraTapHeader::GetRssiReceiverCurrent() const
+{
+    if (!HasRssiReceiverCurrent())
+    {
+        return NAN;
+    }
+
+    return (int32_t)m_rssiCurrent + (int32_t)RSSI_FLOOR;
+}
+
+void
+LoraTapHeader::SetSignalToNoise(double snr)
+{
+    const double max = INT8_MAX * 4;
+    const double min = INT8_MIN * 4;
+
+    if (snr >= max)
+    {
+        m_snr = INT8_MAX;
+        return;
+    }
+
+    if (snr <= min)
+    {
+        m_snr = INT8_MIN;
+        return;
+    }
+
+    m_snr = (int8_t)(4.0 * snr);
+}
+
+double
+LoraTapHeader::GetSignalToNoise() const
+{
+    return 0.25 * m_snr;
+}
+
+void
+LoraTapHeader::SetSyncWord(uint8_t syncWord)
+{
+    m_sync = syncWord;
+}
+
+uint8_t
+LoraTapHeader::GetSyncWord() const
+{
+    return m_sync;
+}
+
+} // namespace lorawan
+} // namespace ns3

--- a/model/loratap-header.h
+++ b/model/loratap-header.h
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2025 ML!PA Consulting GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Author: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef LORATAP_HEADER_H
+#define LORATAP_HEADER_H
+
+#include "lora-tag.h"
+
+#include "ns3/header.h"
+
+namespace ns3
+{
+namespace lorawan
+{
+
+/**
+ * @ingroup lorawan
+ *
+ * This class represents the LoRaTap header as defined in
+ * https://github.com/eriknl/LoRaTap/blob/master/loratap.h, for compatibility
+ * with the wireshark disscector. The format looks like this:
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |    Version    |    Padding    |         Header Length         |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                   Channel Frequency [Hz]                      |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |   Bandwidth   |       SF      |   RSSI[PKT]   |  RSSI[MAX]    |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |   RSSI[CUR]   |      SNR      |   Sync Word   |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * Version:
+ *     Version of the LoRaTap header. We use version 0.
+ *
+ * Padding:
+ *     Unused
+ *
+ * Header Length:
+ *     Length of the LoRaTap header. Big Endian.
+ *
+ * Channel Frequency [Hz]:
+ *     Frequency the frame was send/received at in Hz. Big Endian.
+ *
+ * Bandwitdth:
+ *     Channel Bandwidth in steps of 125 kHz. (0 ↦ 0 kHz, 1 ↦ 125 kHz, ...)
+ *
+ * SF:
+ *     Spreading factor
+ *
+ * RSSI[PKT]:
+ *     Packet RSSI in dBm starting from -139 dBm. If SNR is negative in steps
+ *     of 0.25 dBm, otherwise in steps of 1 dBm. 0xff means unspecified.
+ *
+ *     0xff ↦ n.d.
+ *     SNR ≥ 0: 0x00 ↦ -139 dBm, 0x01 ↦ -138 dBm, 0x02 ↦ -137 dBm, ...
+ *     SNR < 0: 0x00 ↦ -139 dBm, 0x01 ↦ -138.75 dBm, 0x02 ↦ -138.5 dBm, ...
+ *
+ * RSSI[MAX]:
+ *     LoRa receiver maximum RSSI in dBm from -139 dBm.
+ *
+ *     0 ↦ -139 dBm, 1 ↦ -138 dBm, ...
+ *
+ * RSSI[CUR]:
+ *     Current RSSI in dBm starting from -139 dBm. 0xff means unspecified
+ *
+ *     0x00 ↦ -139 dBm, 0x01 ↦ -138 dBm, ..., 0xfe ↦ 115 dBm, 0xff ↦ n.d.
+ *
+ * SNR:
+ *     Signal to noise ratio. Twos' complement in steps of 0.25 dB.
+ *
+ *     0x00 ↦ 0.00 dB, 0x01 ↦ 0.25 dB, ... 0x7f ↦ 31.75 dB,
+ *     0x80 ↦ -32 dB, ..., 0xff ↦ -0.25 dB
+ *
+ * Sync Word:
+ *     LoRa radio sync word. (0x34 = LoRaWAN)
+ *
+ *
+ */
+class LoraTapHeader : public Header
+{
+  public:
+    LoraTapHeader(); //!< Default constructor
+    /**
+     * Constructor initializing LoraTapHeader with the details from the given
+     * tag.
+     *
+     * @param tag The LoRa Tag to read the transmission details from
+     */
+    LoraTapHeader(const LoraTag& tag);
+    ~LoraTapHeader() override; //!< Destructor
+
+    // Methods inherited from Header
+
+    /**
+     *  Register this type.
+     *  @return The object TypeId.
+     */
+    static TypeId GetTypeId();
+    TypeId GetInstanceTypeId() const override;
+
+    /**
+     * Return the size required for serialization of this header.
+     *
+     * @return The serialized size in bytes.
+     */
+    uint32_t GetSerializedSize() const override;
+
+    /**
+     * Serialize the header.
+     *
+     * See Page 15 of LoraWAN specification for a representation of fields.
+     *
+     * @param start A pointer to the buffer that will be filled with the
+     * serialization.
+     */
+    void Serialize(Buffer::Iterator start) const override;
+
+    /**
+     * Deserialize the contents of the buffer into a LoraTapHeader object.
+     *
+     * @param start A pointer to the buffer we need to deserialize.
+     * @return The number of consumed bytes.
+     */
+    uint32_t Deserialize(Buffer::Iterator start) override;
+
+    /**
+     * Print the header in a human-readable format.
+     *
+     * @param os The std::ostream on which to print the header.
+     */
+    void Print(std::ostream& os) const override;
+
+    /**
+     * Set the channel frequency used.
+     *
+     * @param frequencyHz Channel frequency in Hz
+     */
+    void SetChannelFrequency(uint32_t frequencyHz);
+
+    /**
+     * Get the used channel frequency
+     */
+    uint32_t GetChannelFrequency() const;
+
+    /**
+     * Set the channel bandwidth
+     *
+     * @param bandwidthHz Channel bandwidth in Hz
+     *
+     * @details This is internally rounded to the closest multiple of 125 kHz
+     */
+    void SetChannelBandwidth(uint32_t bandwidthHz);
+
+    /**
+     * Get the channel bandwidth in Hz
+     */
+    uint32_t GetChannelBandwidth() const;
+
+    /**
+     * Set the spreading factor
+     *
+     * @param sf The spreacing factor
+     */
+    void SetSpreadingFactor(uint8_t sf);
+
+    /**
+     * Get the spreading factor
+     */
+    uint8_t GetSpreadingFactor() const;
+
+    /**
+     * Set the packet RSSI value in dBm
+     *
+     * @param rssi The packet RSSI value in dBm
+     */
+    void SetRssiPacket(double rssi);
+
+    /**
+     * Clear the packet RSSI value
+     *
+     * Store that no packet RSSI info is available
+     */
+    void ClearRssiPacket();
+
+    /**
+     * Is a packet RSSI value provided?
+     */
+    bool HasRssiPacket() const;
+
+    /**
+     * Get the packet RSSI value in dBm
+     */
+    double GetRssiPacket() const;
+
+    /**
+     * Set the maximum receiver RSSI value in dBm
+     *
+     * @param rssi The maximum receiver RSSI value in dBm
+     */
+    void SetRssiReceiverMax(double rssi);
+
+    /**
+     * Clear the maximum receiver RSSI value
+     *
+     * Store that no maximum receiver RSSI info is available
+     */
+    void ClearRssiReceiverMax();
+
+    /**
+     * Is a maximum receiver RSSI value provided?
+     */
+    bool HasRssiReceiverMax() const;
+
+    /**
+     * Get the maximum receiver RSSI value in dBm
+     */
+    double GetRssiReceiverMax() const;
+
+    /**
+     * Set the current receiver RSSI value in dBm
+     *
+     * @param rssi The current receiver RSSI value in dBm
+     */
+    void SetRssiReceiverCurrent(double rssi);
+
+    /**
+     * Clear the current receiver RSSI value
+     *
+     * Store that no current receiver RSSI info is available
+     */
+    void ClearRssiReceiverCurrent();
+
+    /**
+     * Is a current receiver RSSI value provided?
+     */
+    bool HasRssiReceiverCurrent() const;
+
+    /**
+     * Get the current receiver RSSI value in dBm
+     */
+    double GetRssiReceiverCurrent() const;
+
+    /**
+     * Set the signal to noise ratio in milli-dB
+     *
+     * @param snr SNR in dB
+     */
+    void SetSignalToNoise(double snr);
+
+    /**
+     * Get the signal to noise ration in milli-dB
+     */
+    double GetSignalToNoise() const;
+
+    /**
+     * Set the sync word (e. g. 0x34 for LoRaWAN)
+     */
+    void SetSyncWord(uint8_t syncWord);
+
+    /**
+     * Get the sync word
+     */
+    uint8_t GetSyncWord() const;
+
+  private:
+    uint32_t m_frequencyHz;    //!< Channel frequency in Hz
+    uint8_t m_bandwidthHz;     //!< Channel bandwidth in multiples of 125 kHz
+    uint8_t m_spreadingFactor; //!< Spreading factor
+    // We cannot go for serialization friendly format for packet RSSI, as
+    // serialization format depends on SNR.
+    double m_rssiPkt;      //!< Packet RSSI in dBm from -139 dBm in steps of 0.25
+                           //!< dBm or 1 dBm, depending on SNR
+    uint8_t m_rssiMax;     //!< Maximum receiver RSSI in dBm from -139 dBm
+    uint8_t m_rssiCurrent; //!< Current receiver RSSI in dBm from -139 dBm
+    int8_t m_snr;          //!< signal to noise ratio in steps of 0.25 dB
+    uint8_t m_sync;        //!< sync word
+};
+
+} // namespace lorawan
+
+} // namespace ns3
+#endif

--- a/model/simple-end-device-lora-phy.cc
+++ b/model/simple-end-device-lora-phy.cc
@@ -68,10 +68,12 @@ SimpleEndDeviceLoraPhy::Send(Ptr<Packet> packet,
     // We can send the packet: switch to the TX state
     SwitchToTx(txPowerDbm);
 
-    // Tag the packet with information about its Spreading Factor
+    // Tag the packet with information the transmission channel
     LoraTag tag;
     packet->RemovePacketTag(tag);
     tag.SetSpreadingFactor(txParams.sf);
+    tag.SetFrequency(frequencyHz);
+    tag.SetChannelBandwidth(txParams.bandwidthHz);
     packet->AddPacketTag(tag);
 
     // Send the packet over the channel

--- a/test/pcap-serialization-test-suite.cc
+++ b/test/pcap-serialization-test-suite.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2025 ML!PA Consulting GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Author: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+// Include headers of classes to test
+#include "ns3/log.h"
+#include "ns3/loratap-header.h"
+
+// An essential include is test.h
+#include "ns3/test.h"
+
+#include <cmath>
+
+using namespace ns3;
+using namespace lorawan;
+
+NS_LOG_COMPONENT_DEFINE("PcapSerializationTestSuite");
+
+/**
+ * @ingroup lorawan
+ *
+ * It tests the correct functionality of serialization and deserialization of
+ * LoRa frames for PCap exporting is tested
+ */
+class LoraTapHeaderTest : public TestCase
+{
+  public:
+    LoraTapHeaderTest(); //!< Default constructor
+
+  private:
+    void DoRun() override;
+    void RunGetterSetterTest();
+    void RunSimpleSerializationDeserializationTest();
+    void RunConstructionFromLoraTagTest();
+};
+
+LoraTapHeaderTest::LoraTapHeaderTest()
+    : TestCase("Verify correct seralization and deserialization of LoRa Frames")
+{
+}
+
+void
+LoraTapHeaderTest::RunGetterSetterTest()
+{
+    const uint32_t frequencyHz = 868100000;
+    const uint32_t bandwidthHz = 125000;
+    const uint8_t spreading = 10;
+    const double snrDb = -9.75;
+    const double rssiMaxDbm = -30;
+    const uint8_t sync = 0x34;
+    const double rssiCurrentDbm = -40;
+    const double rssiPacketDbm = -50;
+
+    LoraTapHeader loratap;
+    loratap.SetChannelFrequency(frequencyHz);
+    loratap.SetChannelBandwidth(bandwidthHz);
+    loratap.SetSpreadingFactor(spreading);
+    loratap.SetSignalToNoise(snrDb);
+    loratap.SetSyncWord(sync);
+
+    // Check that HasRssiFoobar() says false when there is *NO* RSSI info
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiPacket(), false, "No RSSI info provided yet");
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiReceiverCurrent(), false, "No RSSI info provided yet");
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiReceiverMax(), false, "No RSSI info provided yet");
+
+    loratap.SetRssiPacket(rssiPacketDbm);
+    loratap.SetRssiReceiverCurrent(rssiCurrentDbm);
+    loratap.SetRssiReceiverMax(rssiMaxDbm);
+
+    // Check that HasRssiFoobar() says true when there *IS* RSSI info
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiPacket(), true, "RSSI info provided ");
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiReceiverCurrent(), true, "RSSI info provided");
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiReceiverMax(), true, "RSSI info provided");
+
+    // Check if getters work as expected
+    NS_TEST_EXPECT_MSG_EQ(loratap.GetChannelFrequency(), frequencyHz, "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(loratap.GetChannelBandwidth(), bandwidthHz, "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(loratap.GetSpreadingFactor(), spreading, "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(TestDoubleIsEqual(loratap.GetSignalToNoise(), snrDb),
+                          true,
+                          "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(loratap.GetSyncWord(), sync, "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(TestDoubleIsEqual(loratap.GetRssiPacket(), rssiPacketDbm),
+                          true,
+                          "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(TestDoubleIsEqual(loratap.GetRssiReceiverCurrent(), rssiCurrentDbm),
+                          true,
+                          "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(TestDoubleIsEqual(loratap.GetRssiReceiverMax(), rssiMaxDbm),
+                          true,
+                          "Getter/setter misbehaving");
+
+    // Check that clearing RSSI info works
+    loratap.ClearRssiPacket();
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiPacket(), false, "RSSI info cleared");
+    loratap.ClearRssiReceiverCurrent();
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiReceiverCurrent(), false, "RSSI info cleared");
+    loratap.ClearRssiReceiverMax();
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiReceiverMax(), false, "RSSI info cleared");
+}
+
+void
+LoraTapHeaderTest::RunSimpleSerializationDeserializationTest()
+{
+    const uint32_t frequencyHz = 868100000;
+    const uint32_t bandwidthHz = 125000;
+    const uint8_t spreading = 10;
+    const double snrDb = -9.75;
+    const double rssiMaxDbm = -30;
+    const uint8_t sync = 0x34;
+    const double rssiCurrentDbm = -40;
+    const double rssiPacketDbm = -80;
+
+    LoraTapHeader loratap;
+    loratap.SetChannelFrequency(frequencyHz);
+    loratap.SetChannelBandwidth(bandwidthHz);
+    loratap.SetSpreadingFactor(spreading);
+    loratap.SetSignalToNoise(snrDb);
+    loratap.SetSyncWord(sync);
+    loratap.SetRssiPacket(rssiPacketDbm);
+    loratap.SetRssiReceiverCurrent(rssiCurrentDbm);
+    loratap.SetRssiReceiverMax(rssiMaxDbm);
+
+    const uint8_t expected[] =
+        {0x00, 0x00, 0x00, 0x0f, 0x33, 0xbe, 0x27, 0xa0, 0x01, 0x0a, 0xec, 0x6d, 0x63, 0xd9, 0x34};
+    uint8_t tmp[sizeof(expected)];
+    memset(tmp, 0xff, sizeof(tmp));
+
+    Buffer buf;
+    buf.AddAtStart(sizeof(expected));
+    auto tapSerialized = buf.Begin();
+    loratap.Serialize(tapSerialized);
+
+    NS_TEST_ASSERT_MSG_EQ(tapSerialized.GetSize(),
+                          sizeof(expected),
+                          "Expected and actual serialization must match in size");
+
+    tapSerialized.Read(tmp, sizeof(tmp));
+    NS_TEST_EXPECT_MSG_EQ(memcmp(tmp, expected, sizeof(expected)),
+                          0,
+                          "Expected and actual serialization need to be bitwise identical");
+
+    // Quickly testing that packet RSSI is correctly serialized when SNR >= 0
+    loratap.SetSignalToNoise(0);
+    tapSerialized = buf.Begin();
+    loratap.Serialize(tapSerialized);
+    tapSerialized.Read(tmp, sizeof(tmp));
+    const unsigned rssiPktPos = 10;
+    NS_TEST_EXPECT_MSG_EQ(tmp[rssiPktPos],
+                          (int32_t)rssiPacketDbm + 139,
+                          "Serialization of packet RSSI needs to change depending on SNR value");
+}
+
+void
+LoraTapHeaderTest::RunConstructionFromLoraTagTest()
+{
+    const uint32_t frequencyHz = 868100000;
+    const uint32_t bandwidthHz = 125000;
+    const uint8_t spreading = 10;
+    const double snrDb = 0.0; // TODO: Add SNR info to LoraTag
+    const uint8_t sync = 0x34;
+    const double rssiDbm = -80;
+
+    LoraTag tag;
+
+    tag.SetFrequency(frequencyHz);
+    tag.SetReceivePower(rssiDbm);
+    tag.SetSpreadingFactor(spreading);
+
+    LoraTapHeader loratap(tag);
+
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiPacket(), true, "Packet RSSI info provided");
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiReceiverCurrent(),
+                          false,
+                          "No receiver RSSI info provided yet");
+    NS_TEST_EXPECT_MSG_EQ(loratap.HasRssiReceiverMax(),
+                          false,
+                          "No receiver RSSI info provided yet");
+    NS_TEST_EXPECT_MSG_EQ(loratap.GetChannelFrequency(), frequencyHz, "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(loratap.GetChannelBandwidth(), bandwidthHz, "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(loratap.GetSpreadingFactor(), spreading, "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(TestDoubleIsEqual(loratap.GetSignalToNoise(), snrDb),
+                          true,
+                          "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(loratap.GetSyncWord(), sync, "Getter/setter misbehaving");
+    NS_TEST_EXPECT_MSG_EQ(TestDoubleIsEqual(loratap.GetRssiPacket(), rssiDbm),
+                          true,
+                          "Getter/setter misbehaving");
+}
+
+void
+LoraTapHeaderTest::DoRun()
+{
+    NS_LOG_DEBUG("LoraTapHeaderTest");
+
+    RunGetterSetterTest();
+    RunSimpleSerializationDeserializationTest();
+    RunConstructionFromLoraTagTest();
+}
+
+/**
+ * @ingroup lorawan
+ *
+ * This TestSuite contains the test for PCAP serialization code and related
+ * helpers.
+ */
+class LorawanPcapSerializationTestSuite : public TestSuite
+{
+  public:
+    LorawanPcapSerializationTestSuite(); //!< Default constructor
+};
+
+LorawanPcapSerializationTestSuite::LorawanPcapSerializationTestSuite()
+    : TestSuite("lorawan-pcap-serialization", Type::UNIT)
+{
+    AddTestCase(new LoraTapHeaderTest, Duration::QUICK);
+}
+
+// Do not forget to allocate an instance of this TestSuite
+static LorawanPcapSerializationTestSuite lorawanPcapSerializationTestSuite;


### PR DESCRIPTION
This pull request fixes issue https://github.com/signetlabdei/lorawan/issues/87

## Proposed Changes

  - Extend the LoraTag to allow getting/setting the channel bandwidth, SNR, and sync word
    - For now, no real users are added that set them, but the default value for the bandwidth (125 kHz) and the sync word (0x34, LoRaWAN) do match what the simulation will do
  - Add a LoraTapHeader that implements the [LoRaTap][1] format
    - decent unit test coverage is provided for the new class
  - Extend the LoraHelper to allow PCAP export using the [LoRaTap][1] format implemented in the LoraTapHeader
  - Extend the complete network example with the `--pcap` option to make use of this

## Missing Gaps

  - The [LoRaTap][1] format exposes more info than currently available. While the LoraTag has been extended to fill those, no meaningful data is added yet.
    - Adding full support for channels with bandwidth differing from 125 kHz is complex enough for a dedicated PR, as
      - it requires updating the logic detecting when a packet is lost due to channel mismatch (as now a receiver may be listening in on the right frequency, but is not demodulating the used bandwidth)
      - it requires updating the interference logic, as another packet may only partially overlap with the target packet due to mismatching channel bandwidth
    - Adding SNR estimation to the interference helper can benefit from some focused discussion in a separate PR

## Testing

  - The serialization and deserialization of the LoRaTap format is covered by the unit test and should be pretty decent
  - In addition, the updated example can now be used with `--pcap` to create actual PCAP files that can be visualized e.g. in Wireshark

> ![WARNING]
> While the LoRaTap header in wireshark looks good, Wireshark is complaining about a malformed LoRaWAN MAC header following the LoRaTap header. I have not yet checked why this is.

[1]: https://github.com/eriknl/LoRaTap/tree/master