### PR TITLE
EndDeviceLoraPhy::State: Add operator<<()

### DIFF
--- a/model/class-a-end-device-lorawan-mac.cc
+++ b/model/class-a-end-device-lorawan-mac.cc
@@ -323,15 +323,15 @@ ClassAEndDeviceLorawanMac::CloseFirstReceiveWindow()
     // We should never be in TX or SLEEP mode at this point
     switch (phy->GetState())
     {
-    case EndDeviceLoraPhy::TX:
+    case EndDeviceLoraPhy::State::TX:
         NS_ABORT_MSG("PHY was in TX mode when attempting to close a receive window.");
         break;
-    case EndDeviceLoraPhy::RX:
+    case EndDeviceLoraPhy::State::RX:
         // PHY is receiving: let it finish. The Receive method will switch it back to SLEEP.
-    case EndDeviceLoraPhy::SLEEP:
+    case EndDeviceLoraPhy::State::SLEEP:
         // PHY has received, and the MAC's Receive already put the device to sleep
         break;
-    case EndDeviceLoraPhy::STANDBY:
+    case EndDeviceLoraPhy::State::STANDBY:
         // Turn PHY layer to SLEEP
         phy->SwitchToSleep();
         break;
@@ -345,7 +345,7 @@ ClassAEndDeviceLorawanMac::OpenSecondReceiveWindow()
 
     // Check for receiver status: if it's locked on a packet, don't open this
     // window at all.
-    if (DynamicCast<EndDeviceLoraPhy>(m_phy)->GetState() == EndDeviceLoraPhy::RX)
+    if (DynamicCast<EndDeviceLoraPhy>(m_phy)->GetState() == EndDeviceLoraPhy::State::RX)
     {
         NS_LOG_INFO("Won't open second receive window since we are in RX mode.");
 
@@ -382,22 +382,22 @@ ClassAEndDeviceLorawanMac::CloseSecondReceiveWindow()
 
     Ptr<EndDeviceLoraPhy> phy = DynamicCast<EndDeviceLoraPhy>(m_phy);
 
-    // NS_ASSERT (phy->m_state != EndDeviceLoraPhy::TX &&
-    // phy->m_state != EndDeviceLoraPhy::SLEEP);
+    // NS_ASSERT (phy->m_state != EndDeviceLoraPhy::State::TX &&
+    // phy->m_state != EndDeviceLoraPhy::State::SLEEP);
 
     // Check the Phy layer's state:
     // - RX -> We have received a preamble.
     // - STANDBY -> Nothing was detected.
     switch (phy->GetState())
     {
-    case EndDeviceLoraPhy::TX:
-    case EndDeviceLoraPhy::SLEEP:
+    case EndDeviceLoraPhy::State::TX:
+    case EndDeviceLoraPhy::State::SLEEP:
         break;
-    case EndDeviceLoraPhy::RX:
+    case EndDeviceLoraPhy::State::RX:
         // PHY is receiving: let it finish
         NS_LOG_DEBUG("PHY is receiving: Receive will handle the result.");
         return;
-    case EndDeviceLoraPhy::STANDBY:
+    case EndDeviceLoraPhy::State::STANDBY:
         // Turn PHY layer to sleep
         phy->SwitchToSleep();
         break;
@@ -414,7 +414,7 @@ ClassAEndDeviceLorawanMac::CloseSecondReceiveWindow()
         }
 
         else if (m_retxParams.retxLeft == 0 &&
-                 DynamicCast<EndDeviceLoraPhy>(m_phy)->GetState() != EndDeviceLoraPhy::RX)
+                 DynamicCast<EndDeviceLoraPhy>(m_phy)->GetState() != EndDeviceLoraPhy::State::RX)
         {
             uint8_t txs = m_nbTrans - (m_retxParams.retxLeft);
             m_requiredTxCallback(txs, false, m_retxParams.firstAttempt, m_retxParams.packet);

--- a/model/end-device-lora-phy.cc
+++ b/model/end-device-lora-phy.cc
@@ -61,7 +61,7 @@ EndDeviceLoraPhy::GetTypeId()
 // Initialize the device with some common settings.
 // These will then be changed by helpers.
 EndDeviceLoraPhy::EndDeviceLoraPhy()
-    : m_state(SLEEP),
+    : m_state(State::SLEEP),
       m_frequencyHz(868100000),
       m_sf(7)
 {
@@ -91,7 +91,7 @@ EndDeviceLoraPhy::GetSpreadingFactor() const
 bool
 EndDeviceLoraPhy::IsTransmitting()
 {
-    return m_state == TX;
+    return m_state == State::TX;
 }
 
 bool
@@ -125,7 +125,7 @@ EndDeviceLoraPhy::SwitchToStandby()
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    m_state = STANDBY;
+    m_state = State::STANDBY;
 
     // Notify listeners of the state change
     for (auto i = m_listeners.begin(); i != m_listeners.end(); i++)
@@ -139,9 +139,9 @@ EndDeviceLoraPhy::SwitchToRx()
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    NS_ASSERT(m_state == STANDBY);
+    NS_ASSERT(m_state == State::STANDBY);
 
-    m_state = RX;
+    m_state = State::RX;
 
     // Notify listeners of the state change
     for (auto i = m_listeners.begin(); i != m_listeners.end(); i++)
@@ -155,9 +155,9 @@ EndDeviceLoraPhy::SwitchToTx(double txPowerDbm)
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    NS_ASSERT(m_state != RX);
+    NS_ASSERT(m_state != State::RX);
 
-    m_state = TX;
+    m_state = State::TX;
 
     // Notify listeners of the state change
     for (auto i = m_listeners.begin(); i != m_listeners.end(); i++)
@@ -171,9 +171,9 @@ EndDeviceLoraPhy::SwitchToSleep()
 {
     NS_LOG_FUNCTION_NOARGS();
 
-    NS_ASSERT(m_state == STANDBY);
+    NS_ASSERT(m_state == State::STANDBY);
 
-    m_state = SLEEP;
+    m_state = State::SLEEP;
 
     // Notify listeners of the state change
     for (auto i = m_listeners.begin(); i != m_listeners.end(); i++)

--- a/model/end-device-lora-phy.cc
+++ b/model/end-device-lora-phy.cc
@@ -206,5 +206,27 @@ EndDeviceLoraPhy::UnregisterListener(EndDeviceLoraPhyListener* listener)
     }
 }
 
+std::ostream&
+operator<<(std::ostream& os, const EndDeviceLoraPhy::State& state)
+{
+    static const char* map[] = {
+        "SLEEP",
+        "STANDBY",
+        "TX",
+        "RX",
+    };
+
+    if (static_cast<size_t>(state) >= std::size(map))
+    {
+        os << "<INVALID>";
+    }
+    else
+    {
+        os << map[static_cast<size_t>(state)];
+    }
+
+    return os;
+}
+
 } // namespace lorawan
 } // namespace ns3

--- a/model/end-device-lora-phy.cc
+++ b/model/end-device-lora-phy.cc
@@ -209,23 +209,19 @@ EndDeviceLoraPhy::UnregisterListener(EndDeviceLoraPhyListener* listener)
 std::ostream&
 operator<<(std::ostream& os, const EndDeviceLoraPhy::State& state)
 {
-    static const char* map[] = {
-        "SLEEP",
-        "STANDBY",
-        "TX",
-        "RX",
-    };
-
-    if (static_cast<size_t>(state) >= std::size(map))
+    switch (state)
     {
-        os << "<INVALID>";
+    case EndDeviceLoraPhy::State::SLEEP:
+        return (os << "SLEEP");
+    case EndDeviceLoraPhy::State::STANDBY:
+        return (os << "STANDBY");
+    case EndDeviceLoraPhy::State::TX:
+        return (os << "TX");
+    case EndDeviceLoraPhy::State::RX:
+        return (os << "RX");
+    default:
+        NS_FATAL_ERROR("Invalid LoRa device PHY state");
     }
-    else
-    {
-        os << map[static_cast<size_t>(state)];
-    }
-
-    return os;
 }
 
 } // namespace lorawan

--- a/model/end-device-lora-phy.h
+++ b/model/end-device-lora-phy.h
@@ -130,6 +130,7 @@ class EndDeviceLoraPhy : public LoraPhy
          * not possible.
          */
         RX
+        // NOTE: When extending/updating, please update operator<< accordingly.
     };
 
     /**
@@ -278,6 +279,11 @@ class EndDeviceLoraPhy : public LoraPhy
 
     Listeners m_listeners; //!< PHY listeners
 };
+
+/**
+ * Allow logging of EndDeviceLoraPhy::State like with any other data type.
+ */
+std::ostream& operator<<(std::ostream& os, const EndDeviceLoraPhy::State& state);
 
 } // namespace lorawan
 

--- a/model/end-device-lora-phy.h
+++ b/model/end-device-lora-phy.h
@@ -281,11 +281,15 @@ class EndDeviceLoraPhy : public LoraPhy
 };
 
 /**
- * Allow logging of EndDeviceLoraPhy::State like with any other data type.
+ *  Overloaded operator to print the value of a EndDeviceLoraPhy::State.
+ *
+ *  @param os The output stream
+ *  @param state The enum value of the PHY state
+ *  @return The output stream with text value of the PHY state
  */
 std::ostream& operator<<(std::ostream& os, const EndDeviceLoraPhy::State& state);
 
 } // namespace lorawan
-
 } // namespace ns3
+
 #endif /* END_DEVICE_LORA_PHY_H */

--- a/model/end-device-lora-phy.h
+++ b/model/end-device-lora-phy.h
@@ -102,7 +102,7 @@ class EndDeviceLoraPhy : public LoraPhy
      * demodulator which can either send, receive, stay idle or go in a deep
      * sleep state.
      */
-    enum State
+    enum class State
     {
         /**
          * The PHY layer is sleeping.

--- a/model/lora-radio-energy-model.cc
+++ b/model/lora-radio-energy-model.cc
@@ -70,7 +70,7 @@ LoraRadioEnergyModel::GetTypeId()
 LoraRadioEnergyModel::LoraRadioEnergyModel()
 {
     NS_LOG_FUNCTION(this);
-    m_currentState = EndDeviceLoraPhy::SLEEP; // initially STANDBY
+    m_currentState = EndDeviceLoraPhy::State::SLEEP;
     m_lastUpdateTime = Seconds(0.0);
     m_nPendingChangeState = 0;
     m_isSupersededChangeState = false;
@@ -208,7 +208,7 @@ LoraRadioEnergyModel::SetTxCurrentFromModel(double txPowerDbm)
 void
 LoraRadioEnergyModel::ChangeState(int newState)
 {
-    NS_LOG_FUNCTION(this << newState);
+    NS_LOG_FUNCTION(this << EndDeviceLoraPhy::State(newState));
 
     Time duration = Now() - m_lastUpdateTime;
     NS_ASSERT(duration.IsPositive()); // check if duration is valid
@@ -218,16 +218,16 @@ LoraRadioEnergyModel::ChangeState(int newState)
     double supplyVoltage = m_source->GetSupplyVoltage();
     switch (m_currentState)
     {
-    case EndDeviceLoraPhy::STANDBY:
+    case EndDeviceLoraPhy::State::STANDBY:
         energyToDecrease = duration.GetSeconds() * m_idleCurrentA * supplyVoltage;
         break;
-    case EndDeviceLoraPhy::TX:
+    case EndDeviceLoraPhy::State::TX:
         energyToDecrease = duration.GetSeconds() * m_txCurrentA * supplyVoltage;
         break;
-    case EndDeviceLoraPhy::RX:
+    case EndDeviceLoraPhy::State::RX:
         energyToDecrease = duration.GetSeconds() * m_rxCurrentA * supplyVoltage;
         break;
-    case EndDeviceLoraPhy::SLEEP:
+    case EndDeviceLoraPhy::State::SLEEP:
         energyToDecrease = duration.GetSeconds() * m_sleepCurrentA * supplyVoltage;
         break;
     default:
@@ -255,7 +255,7 @@ LoraRadioEnergyModel::ChangeState(int newState)
     if (!m_isSupersededChangeState)
     {
         // update current state & last update time stamp
-        SetLoraRadioState((EndDeviceLoraPhy::State)newState);
+        SetLoraRadioState(EndDeviceLoraPhy::State(newState));
 
         // some debug message
         NS_LOG_DEBUG("LoraRadioEnergyModel:Total energy consumption is " << m_totalEnergyConsumption
@@ -323,13 +323,13 @@ LoraRadioEnergyModel::DoGetCurrentA() const
     NS_LOG_FUNCTION(this);
     switch (m_currentState)
     {
-    case EndDeviceLoraPhy::STANDBY:
+    case EndDeviceLoraPhy::State::STANDBY:
         return m_idleCurrentA;
-    case EndDeviceLoraPhy::TX:
+    case EndDeviceLoraPhy::State::TX:
         return m_txCurrentA;
-    case EndDeviceLoraPhy::RX:
+    case EndDeviceLoraPhy::State::RX:
         return m_rxCurrentA;
-    case EndDeviceLoraPhy::SLEEP:
+    case EndDeviceLoraPhy::State::SLEEP:
         return m_sleepCurrentA;
     default:
         NS_FATAL_ERROR("LoraRadioEnergyModel:Undefined radio state:" << m_currentState);
@@ -341,24 +341,7 @@ LoraRadioEnergyModel::SetLoraRadioState(const EndDeviceLoraPhy::State state)
 {
     NS_LOG_FUNCTION(this << state);
     m_currentState = state;
-    std::string stateName;
-    switch (state)
-    {
-    case EndDeviceLoraPhy::STANDBY:
-        stateName = "STANDBY";
-        break;
-    case EndDeviceLoraPhy::TX:
-        stateName = "TX";
-        break;
-    case EndDeviceLoraPhy::RX:
-        stateName = "RX";
-        break;
-    case EndDeviceLoraPhy::SLEEP:
-        stateName = "SLEEP";
-        break;
-    }
-    NS_LOG_DEBUG("LoraRadioEnergyModel:Switching to state: " << stateName
-                                                             << " at time = " << Now().As(Time::S));
+    NS_LOG_DEBUG("Switching to state: " << state);
 }
 
 // -------------------------------------------------------------------------- //
@@ -400,7 +383,7 @@ LoraRadioEnergyModelPhyListener::NotifyRxStart()
     {
         NS_FATAL_ERROR("LoraRadioEnergyModelPhyListener:Change state callback not set!");
     }
-    m_changeStateCallback(EndDeviceLoraPhy::RX);
+    m_changeStateCallback(int(EndDeviceLoraPhy::State::RX));
 }
 
 void
@@ -416,7 +399,7 @@ LoraRadioEnergyModelPhyListener::NotifyTxStart(double txPowerDbm)
     {
         NS_FATAL_ERROR("LoraRadioEnergyModelPhyListener:Change state callback not set!");
     }
-    m_changeStateCallback(EndDeviceLoraPhy::TX);
+    m_changeStateCallback(int(EndDeviceLoraPhy::State::TX));
 }
 
 void
@@ -427,7 +410,7 @@ LoraRadioEnergyModelPhyListener::NotifySleep()
     {
         NS_FATAL_ERROR("LoraRadioEnergyModelPhyListener:Change state callback not set!");
     }
-    m_changeStateCallback(EndDeviceLoraPhy::SLEEP);
+    m_changeStateCallback(int(EndDeviceLoraPhy::State::SLEEP));
 }
 
 void
@@ -438,7 +421,7 @@ LoraRadioEnergyModelPhyListener::NotifyStandby()
     {
         NS_FATAL_ERROR("LoraRadioEnergyModelPhyListener:Change state callback not set!");
     }
-    m_changeStateCallback(EndDeviceLoraPhy::STANDBY);
+    m_changeStateCallback(int(EndDeviceLoraPhy::State::STANDBY));
 }
 
 /*
@@ -453,7 +436,7 @@ LoraRadioEnergyModelPhyListener::SwitchToStandby()
     {
         NS_FATAL_ERROR("LoraRadioEnergyModelPhyListener:Change state callback not set!");
     }
-    m_changeStateCallback(EndDeviceLoraPhy::STANDBY);
+    m_changeStateCallback(int(EndDeviceLoraPhy::State::STANDBY));
 }
 
 } // namespace lorawan

--- a/model/simple-end-device-lora-phy.cc
+++ b/model/simple-end-device-lora-phy.cc
@@ -56,7 +56,7 @@ SimpleEndDeviceLoraPhy::Send(Ptr<Packet> packet,
     NS_LOG_INFO("Current state: " << m_state);
 
     // We must be either in STANDBY or SLEEP mode to send a packet
-    if (m_state != STANDBY && m_state != SLEEP)
+    if (m_state != State::STANDBY && m_state != State::SLEEP)
     {
         NS_LOG_INFO("Cannot send because device is currently not in STANDBY or SLEEP mode");
         return;
@@ -118,21 +118,21 @@ SimpleEndDeviceLoraPhy::StartReceive(Ptr<Packet> packet,
     // In the SLEEP, TX and RX cases we cannot receive the packet: we only add
     // it to the list of interferers and do not schedule an EndReceive event for
     // it.
-    case SLEEP: {
+    case State::SLEEP: {
         NS_LOG_INFO("Dropping packet because device is in SLEEP state");
         break;
     }
-    case TX: {
+    case State::TX: {
         NS_LOG_INFO("Dropping packet because device is in TX state");
         break;
     }
-    case RX: {
+    case State::RX: {
         NS_LOG_INFO("Dropping packet because device is already in RX state");
         break;
     }
     // If we are in STANDBY mode, we can potentially lock on the currently
     // incoming transmission
-    case STANDBY: {
+    case State::STANDBY: {
         // There are a series of properties the packet needs to respect in order
         // for us to be able to lock on it:
         // - It's on frequency we are listening on

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -2040,57 +2040,6 @@ MacCommandTest::DoRun()
 /**
  * @ingroup lorawan
  *
- * Tests for misc utility function.
- */
-class UtilitiesTest : public TestCase
-{
-  public:
-    UtilitiesTest();           //!< Default constructor
-    ~UtilitiesTest() override; //!< Destructor
-
-    void DoRun() override;
-    /**
-     * Test that the stringification (operator<<()) for the given state does
-     * output the given expected string
-     *
-     * @param state The state to test
-     * @param expected The expected output
-     */
-    void TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State state, const char* expected);
-};
-
-UtilitiesTest::UtilitiesTest()
-    : TestCase("Test of misc ultility functions")
-{
-}
-
-UtilitiesTest::~UtilitiesTest()
-{
-}
-
-void
-UtilitiesTest::DoRun()
-{
-    TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State::RX, "RX");
-    TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State::TX, "TX");
-    TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State::SLEEP, "SLEEP");
-    TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State::STANDBY, "STANDBY");
-}
-
-void
-UtilitiesTest::TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State state,
-                                                    const char* expected)
-{
-    std::ostringstream os;
-    os << state;
-    NS_TEST_EXPECT_MSG_EQ(strcmp(os.str().c_str(), expected),
-                          0,
-                          "Stringification of " << expected << " incorrect");
-}
-
-/**
- * @ingroup lorawan
- *
  * The TestSuite class names the TestSuite, identifies what type of TestSuite, and enables the
  * TestCases to be run. Typically, only the constructor for this class must be defined
  */
@@ -2124,7 +2073,6 @@ LorawanTestSuite::LorawanTestSuite()
     AddTestCase(new TimeOnAirTest, Duration::QUICK);
     AddTestCase(new PhyConnectivityTest, Duration::QUICK);
     AddTestCase(new MacCommandTest, Duration::QUICK);
-    AddTestCase(new UtilitiesTest, Duration::QUICK);
 }
 
 // Do not forget to allocate an instance of this TestSuite

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -1549,10 +1549,10 @@ PhyConnectivityTest::DoRun()
     Simulator::Destroy();
 
     NS_TEST_EXPECT_MSG_EQ(edPhy1->GetState(),
-                          SimpleEndDeviceLoraPhy::STANDBY,
+                          SimpleEndDeviceLoraPhy::State::STANDBY,
                           "State didn't switch to STANDBY as expected");
     NS_TEST_EXPECT_MSG_EQ(edPhy2->GetState(),
-                          SimpleEndDeviceLoraPhy::STANDBY,
+                          SimpleEndDeviceLoraPhy::State::STANDBY,
                           "State didn't switch to STANDBY as expected");
 }
 

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -2040,6 +2040,57 @@ MacCommandTest::DoRun()
 /**
  * @ingroup lorawan
  *
+ * Tests for misc utility function.
+ */
+class UtilitiesTest : public TestCase
+{
+  public:
+    UtilitiesTest();           //!< Default constructor
+    ~UtilitiesTest() override; //!< Destructor
+
+    void DoRun() override;
+    /**
+     * Test that the stringification (operator<<()) for the given state does
+     * output the given expected string
+     *
+     * @param state The state to test
+     * @param expected The expected output
+     */
+    void TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State state, const char* expected);
+};
+
+UtilitiesTest::UtilitiesTest()
+    : TestCase("Test of misc ultility functions")
+{
+}
+
+UtilitiesTest::~UtilitiesTest()
+{
+}
+
+void
+UtilitiesTest::DoRun()
+{
+    TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State::RX, "RX");
+    TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State::TX, "TX");
+    TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State::SLEEP, "SLEEP");
+    TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State::STANDBY, "STANDBY");
+}
+
+void
+UtilitiesTest::TestEndDevicePhyStateStringification(EndDeviceLoraPhy::State state,
+                                                    const char* expected)
+{
+    std::ostringstream os;
+    os << state;
+    NS_TEST_EXPECT_MSG_EQ(strcmp(os.str().c_str(), expected),
+                          0,
+                          "Stringification of " << expected << " incorrect");
+}
+
+/**
+ * @ingroup lorawan
+ *
  * The TestSuite class names the TestSuite, identifies what type of TestSuite, and enables the
  * TestCases to be run. Typically, only the constructor for this class must be defined
  */
@@ -2073,6 +2124,7 @@ LorawanTestSuite::LorawanTestSuite()
     AddTestCase(new TimeOnAirTest, Duration::QUICK);
     AddTestCase(new PhyConnectivityTest, Duration::QUICK);
     AddTestCase(new MacCommandTest, Duration::QUICK);
+    AddTestCase(new UtilitiesTest, Duration::QUICK);
 }
 
 // Do not forget to allocate an instance of this TestSuite


### PR DESCRIPTION
## Proposed Changes

  - Add `operator<<()` to `EndDeviceLoraPhy::State`
    - This makes working with the EndDeviceState trace a bit easier, when the goal is human readable output.
