### PR TITLE
Fix the CI pipeline until ns-3.46 upgrade

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -76,9 +76,16 @@ jobs:
       - run: pip install pyyaml cmake cmake-format ninja wget
       - name: "Checkout this repository as ns-3 module"
         uses: ./.github/actions/checkout-in-ns3
+      - run: ./ns3 configure --enable-modules=core
       - run: |
-          ./ns3 configure --enable-modules=core
-          ./ns3 build cmake-format-check
+          if (! ./ns3 build cmake-format-check) ; then
+            echo "Bad formatting detected in CMake files.";
+            echo "To fix the formatting issues, run the following command:";
+            echo "   $ ./ns3 build cmake-format";
+            echo "Note that it requires having cmake-format installed in your system.";
+            echo "You might need to run \"./ns3 configure\" after installing it.";
+            exit 1;
+          fi
 
   # Markdown linting
   markdown-lint:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,7 +13,7 @@ jobs:
   check-style-clang-format:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:rolling
+      image: ubuntu:25.04
     strategy:
       matrix:
         version: [15, 17]
@@ -65,7 +65,7 @@ jobs:
   cmake-format:
     runs-on: ubuntu-latest
     container:
-      image: python:latest
+      image: python:3.13
     timeout-minutes: 60
     steps:
       # The following step is required in all jobs that use this repo's actions

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -42,7 +42,7 @@ jobs:
       image: python:latest
     timeout-minutes: 60
     env:
-      URL: https://github.com/signetlabdei/lorawan.git
+      URL: ${{ github.server_url }}/${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
       - run: pip install codespell

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       CLANG_TIDY_OUTPUT: clang-tidy-output.log
       FILES_CHANGED: git-diff-name-only.log
-      URL: https://github.com/signetlabdei/lorawan.git
+      URL: ${{ github.server_url }}/${{ github.repository }}
     steps:
       # The following step is required in all jobs that use this repo's actions
       - name: "Retrieve actions from repository"


### PR DESCRIPTION
Some jobs are failing because the latest versions of job containers (e.g., `ubuntu:rolling`) do not offer certain packet versions anymore. We temporarily lock down tags until the module is updated to support ns-3.46 in the next release.

Other minor improvements to the CI are also attached to this PR (see commits).