### PR TITLE
LoraPhy: Use enum for coding rate

### DIFF
--- a/examples/aloha-throughput.cc
+++ b/examples/aloha-throughput.cc
@@ -269,7 +269,7 @@ main(int argc, char* argv[])
         LoraTxParameters txParams;
         txParams.sf = sf;
         txParams.headerDisabled = false;
-        txParams.codingRate = 1;
+        txParams.codingRate = LoraTxParameters::CODING_RATE_4_5;
         txParams.bandwidthHz = 125000;
         txParams.nPreamble = 8;
         txParams.crcEnabled = true;

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -103,7 +103,7 @@ EndDeviceLorawanMac::EndDeviceLorawanMac()
       m_nbTrans(1),
       m_dataRate(0),
       m_txPowerDbm(14),
-      m_codingRate(1),
+      m_codingRate(LoraTxParameters::CODING_RATE_4_5),
       // LoraWAN default
       m_headerDisabled(false),
       // LoraWAN default

--- a/model/end-device-lorawan-mac.h
+++ b/model/end-device-lorawan-mac.h
@@ -332,8 +332,8 @@ class EndDeviceLorawanMac : public LorawanMac
     uint8_t m_nbTrans; //!< Default number of unacknowledged redundant transmissions of each packet.
     TracedValue<uint8_t> m_dataRate; //!< The data rate this device is using to transmit.
     TracedValue<double>
-        m_txPowerDbm;      //!< The transmission ERP [dBm] this device is currently using.
-    uint8_t m_codingRate;  //!< The coding rate used by this device.
+        m_txPowerDbm; //!< The transmission ERP [dBm] this device is currently using.
+    LoraTxParameters::CodingRate m_codingRate; //!< The coding rate used by this device.
     bool m_headerDisabled; //!< Whether or not the LoRa PHY header is disabled for communications by
                            //!< this device.
     LoraDeviceAddress m_address; //!< The address of this device.

--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -70,7 +70,7 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     LoraTxParameters params;
     params.sf = GetSfFromDataRate(dataRate);
     params.headerDisabled = false;
-    params.codingRate = 1;
+    params.codingRate = LoraTxParameters::CODING_RATE_4_5;
     params.bandwidthHz = GetBandwidthFromDataRate(dataRate);
     params.nPreamble = 8;
     params.crcEnabled = true;

--- a/model/lora-phy.h
+++ b/model/lora-phy.h
@@ -36,12 +36,23 @@ class LoraChannel;
  */
 struct LoraTxParameters
 {
-    uint8_t sf = 7;                //!< Spreading Factor
-    bool headerDisabled = false;   //!< Whether to use implicit header mode
-    uint8_t codingRate = 1;        //!< Code rate (obtained as 4/(codingRate+4))
-    uint32_t bandwidthHz = 125000; //!< Bandwidth in Hz
-    uint32_t nPreamble = 8;        //!< Number of preamble symbols
-    bool crcEnabled = true;        //!< Whether Cyclic Redundancy Check (CRC) is enabled
+    /**
+     * Enumeration of the LoRa coding rates supported
+     */
+    enum CodingRate
+    {
+        CODING_RATE_4_5 = 1, //!< Coding rate 4/5
+        CODING_RATE_4_6 = 2, //!< Coding rate 4/6
+        CODING_RATE_4_7 = 3, //!< Coding rate 4/7
+        CODING_RATE_4_8 = 4, //!< Coding rate 4/8
+    };
+
+    uint8_t sf = 7;                          //!< Spreading Factor
+    bool headerDisabled = false;             //!< Whether to use implicit header mode
+    CodingRate codingRate = CODING_RATE_4_5; //!< Code rate (obtained as 4/(codingRate+4))
+    uint32_t bandwidthHz = 125000;           //!< Bandwidth in Hz
+    uint32_t nPreamble = 8;                  //!< Number of preamble symbols
+    bool crcEnabled = true;                  //!< Whether Cyclic Redundancy Check (CRC) is enabled
     bool lowDataRateOptimizationEnabled = false; //!< Whether low data rate optimization is enabled
 };
 

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -1018,7 +1018,7 @@ TimeOnAirTest::DoRun()
     LoraTxParameters txParams;
     txParams.sf = 7;
     txParams.headerDisabled = false;
-    txParams.codingRate = 1;
+    txParams.codingRate = LoraTxParameters::CODING_RATE_4_5;
     txParams.bandwidthHz = 125000;
     txParams.nPreamble = 8;
     txParams.crcEnabled = true;
@@ -1035,7 +1035,7 @@ TimeOnAirTest::DoRun()
     duration = LoraPhy::GetOnAirTime(packet, txParams);
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 0.072192, 0.0001, "Unexpected duration");
 
-    txParams.codingRate = 2;
+    txParams.codingRate = LoraTxParameters::CODING_RATE_4_6;
     duration = LoraPhy::GetOnAirTime(packet, txParams);
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 0.078336, 0.0001, "Unexpected duration");
 
@@ -1079,7 +1079,7 @@ TimeOnAirTest::DoRun()
     duration = LoraPhy::GetOnAirTime(packet, txParams);
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 2.629632, 0.0001, "Unexpected duration");
 
-    txParams.codingRate = 1;
+    txParams.codingRate = LoraTxParameters::CODING_RATE_4_5;
     duration = LoraPhy::GetOnAirTime(packet, txParams);
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 2.301952, 0.0001, "Unexpected duration");
 }


### PR DESCRIPTION
## Proposed Changes

  - `struct` member `uint8_t codingRate` in `struct LoraTxParameters` is changed to an `enum`

This makes reading the code a lot easier compared to the use of "magic numbers".