### PR TITLE
LoraPhy, LoraChannel: simulate sync word behavior

### DIFF
--- a/examples/aloha-throughput.cc
+++ b/examples/aloha-throughput.cc
@@ -269,7 +269,7 @@ main(int argc, char* argv[])
         LoraTxParameters txParams;
         txParams.sf = sf;
         txParams.headerDisabled = false;
-        txParams.codingRate = 1;
+        txParams.codingRate = LoraTxParameters::CODING_RATE_4_5;
         txParams.bandwidthHz = 125000;
         txParams.nPreamble = 8;
         txParams.crcEnabled = true;

--- a/model/end-device-lora-phy.h
+++ b/model/end-device-lora-phy.h
@@ -146,7 +146,8 @@ class EndDeviceLoraPhy : public LoraPhy
                       double rxPowerDbm,
                       uint8_t sf,
                       Time duration,
-                      uint32_t frequencyHz) override = 0;
+                      uint32_t frequencyHz,
+                      uint8_t syncWord) override = 0;
 
     // Implementation of LoraPhy's pure virtual functions
     void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) override = 0;
@@ -266,6 +267,8 @@ class EndDeviceLoraPhy : public LoraPhy
     uint32_t m_frequencyHz; //!< The frequency [Hz] this device is listening on
 
     uint8_t m_sf; //!< The Spreading Factor this device is listening for
+
+    uint8_t m_syncWord; //!< The sync word this device is using
 
     /**
      * typedef for a list of EndDeviceLoraPhyListener.

--- a/model/end-device-lorawan-mac.cc
+++ b/model/end-device-lorawan-mac.cc
@@ -103,7 +103,7 @@ EndDeviceLorawanMac::EndDeviceLorawanMac()
       m_nbTrans(1),
       m_dataRate(0),
       m_txPowerDbm(14),
-      m_codingRate(1),
+      m_codingRate(LoraTxParameters::CODING_RATE_4_5),
       // LoraWAN default
       m_headerDisabled(false),
       // LoraWAN default

--- a/model/end-device-lorawan-mac.h
+++ b/model/end-device-lorawan-mac.h
@@ -332,8 +332,8 @@ class EndDeviceLorawanMac : public LorawanMac
     uint8_t m_nbTrans; //!< Default number of unacknowledged redundant transmissions of each packet.
     TracedValue<uint8_t> m_dataRate; //!< The data rate this device is using to transmit.
     TracedValue<double>
-        m_txPowerDbm;      //!< The transmission ERP [dBm] this device is currently using.
-    uint8_t m_codingRate;  //!< The coding rate used by this device.
+        m_txPowerDbm; //!< The transmission ERP [dBm] this device is currently using.
+    LoraTxParameters::CodingRate m_codingRate; //!< The coding rate used by this device.
     bool m_headerDisabled; //!< Whether or not the LoRa PHY header is disabled for communications by
                            //!< this device.
     LoraDeviceAddress m_address; //!< The address of this device.

--- a/model/gateway-lora-phy.h
+++ b/model/gateway-lora-phy.h
@@ -55,7 +55,8 @@ class GatewayLoraPhy : public LoraPhy
                       double rxPowerDbm,
                       uint8_t sf,
                       Time duration,
-                      uint32_t frequencyHz) override = 0;
+                      uint32_t frequencyHz,
+                      uint8_t syncWord) override = 0;
 
     void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) override = 0;
 

--- a/model/gateway-lorawan-mac.cc
+++ b/model/gateway-lorawan-mac.cc
@@ -70,7 +70,7 @@ GatewayLorawanMac::Send(Ptr<Packet> packet)
     LoraTxParameters params;
     params.sf = GetSfFromDataRate(dataRate);
     params.headerDisabled = false;
-    params.codingRate = 1;
+    params.codingRate = LoraTxParameters::CODING_RATE_4_5;
     params.bandwidthHz = GetBandwidthFromDataRate(dataRate);
     params.nPreamble = 8;
     params.crcEnabled = true;

--- a/model/lora-channel.cc
+++ b/model/lora-channel.cc
@@ -104,7 +104,8 @@ LoraChannel::Send(Ptr<LoraPhy> sender,
                   double txPowerDbm,
                   LoraTxParameters txParams,
                   Time duration,
-                  uint32_t frequencyHz) const
+                  uint32_t frequencyHz,
+                  uint8_t syncWord) const
 {
     NS_LOG_FUNCTION(this << sender << packet << txPowerDbm << txParams << duration << frequencyHz);
 
@@ -160,6 +161,7 @@ LoraChannel::Send(Ptr<LoraPhy> sender,
             parameters.sf = txParams.sf;
             parameters.duration = duration;
             parameters.frequencyHz = frequencyHz;
+            parameters.syncWord = syncWord;
 
             // Schedule the receive event
             NS_LOG_INFO("Scheduling reception of the packet");
@@ -187,7 +189,8 @@ LoraChannel::Receive(uint32_t i, Ptr<Packet> packet, LoraChannelParameters param
                                parameters.rxPowerDbm,
                                parameters.sf,
                                parameters.duration,
-                               parameters.frequencyHz);
+                               parameters.frequencyHz,
+                               parameters.syncWord);
 }
 
 double
@@ -203,7 +206,7 @@ operator<<(std::ostream& os, const LoraChannelParameters& params)
 {
     os << "(rxPowerDbm: " << params.rxPowerDbm << ", SF: " << unsigned(params.sf)
        << ", duration: " << params.duration.As(Time::MS) << ", frequencyHz: " << params.frequencyHz
-       << ")";
+       << ", syncWord: " << params.syncWord << ")";
     return os;
 }
 } // namespace lorawan

--- a/model/lora-channel.h
+++ b/model/lora-channel.h
@@ -45,10 +45,11 @@ struct LoraTxParameters;
  */
 struct LoraChannelParameters
 {
-    double rxPowerDbm;    //!< The reception power.
-    uint8_t sf;           //!< The Spreading Factor of this transmission.
-    Time duration;        //!< The duration of the transmission.
-    uint32_t frequencyHz; //!< The frequency [Hz] of this transmission.
+    double rxPowerDbm;       //!< The reception power.
+    uint8_t sf;              //!< The Spreading Factor of this transmission.
+    Time duration;           //!< The duration of the transmission.
+    uint32_t frequencyHz;    //!< The frequency [Hz] of this transmission.
+    uint8_t syncWord = 0x34; //!< The sync word of this transmission.
 };
 
 /**
@@ -126,6 +127,7 @@ class LoraChannel : public Channel
      * @param txParams The set of parameters that are used by the transmitter.
      * @param duration The on-air duration of this packet.
      * @param frequencyHz The frequency this transmission will happen at.
+     * @param syncWord The sync word of the packet
      *
      * @internal
      *
@@ -137,7 +139,8 @@ class LoraChannel : public Channel
               double txPowerDbm,
               LoraTxParameters txParams,
               Time duration,
-              uint32_t frequencyHz) const;
+              uint32_t frequencyHz,
+              uint8_t syncWord) const;
 
     /**
      * Compute the received power when transmitting from a point to another one.

--- a/model/lora-phy.cc
+++ b/model/lora-phy.cc
@@ -61,11 +61,19 @@ LoraPhy::GetTypeId()
                             "could not be correctly received because"
                             "its received power is below the sensitivity of the receiver",
                             MakeTraceSourceAccessor(&LoraPhy::m_underSensitivity),
+                            "ns3::Packet::TracedCallback")
+            .AddTraceSource("LostPacketBecauseSyncWordMismatch",
+                            "Trace source indicating a packet "
+                            "could not be synced to because a mismatch "
+                            "in the sync word configured in the PHY and used "
+                            "in the packet",
+                            MakeTraceSourceAccessor(&LoraPhy::m_wrongSyncWord),
                             "ns3::Packet::TracedCallback");
     return tid;
 }
 
 LoraPhy::LoraPhy()
+    : m_syncWord(0x34)
 {
 }
 
@@ -85,6 +93,18 @@ LoraPhy::SetDevice(Ptr<NetDevice> device)
     NS_LOG_FUNCTION(this << device);
 
     m_device = device;
+}
+
+uint8_t
+LoraPhy::GetSyncWord() const
+{
+    return m_syncWord;
+}
+
+void
+LoraPhy::SetSyncWord(uint8_t syncWord)
+{
+    m_syncWord = syncWord;
 }
 
 Ptr<LoraChannel>

--- a/model/lora-phy.h
+++ b/model/lora-phy.h
@@ -36,12 +36,23 @@ class LoraChannel;
  */
 struct LoraTxParameters
 {
-    uint8_t sf = 7;                //!< Spreading Factor
-    bool headerDisabled = false;   //!< Whether to use implicit header mode
-    uint8_t codingRate = 1;        //!< Code rate (obtained as 4/(codingRate+4))
-    uint32_t bandwidthHz = 125000; //!< Bandwidth in Hz
-    uint32_t nPreamble = 8;        //!< Number of preamble symbols
-    bool crcEnabled = true;        //!< Whether Cyclic Redundancy Check (CRC) is enabled
+    /**
+     * Enumeration of the LoRa coding rates supported
+     */
+    enum CodingRate
+    {
+        CODING_RATE_4_5 = 1, //!< Coding rate 4/5
+        CODING_RATE_4_6 = 2, //!< Coding rate 4/6
+        CODING_RATE_4_7 = 3, //!< Coding rate 4/7
+        CODING_RATE_4_8 = 4, //!< Coding rate 4/8
+    };
+
+    uint8_t sf = 7;                          //!< Spreading Factor
+    bool headerDisabled = false;             //!< Whether to use implicit header mode
+    CodingRate codingRate = CODING_RATE_4_5; //!< Code rate (obtained as 4/(codingRate+4))
+    uint32_t bandwidthHz = 125000;           //!< Bandwidth in Hz
+    uint32_t nPreamble = 8;                  //!< Number of preamble symbols
+    bool crcEnabled = true;                  //!< Whether Cyclic Redundancy Check (CRC) is enabled
     bool lowDataRateOptimizationEnabled = false; //!< Whether low data rate optimization is enabled
 };
 

--- a/model/lora-phy.h
+++ b/model/lora-phy.h
@@ -119,12 +119,14 @@ class LoraPhy : public Object
      * @param sf The Spreading Factor of the arriving packet.
      * @param duration The on air time of this packet.
      * @param frequencyHz The frequency this packet is being transmitted on.
+     * @param syncWord The sync word this packet was transmitted with
      */
     virtual void StartReceive(Ptr<Packet> packet,
                               double rxPowerDbm,
                               uint8_t sf,
                               Time duration,
-                              uint32_t frequencyHz) = 0;
+                              uint32_t frequencyHz,
+                              uint8_t syncWord) = 0;
 
     /**
      * Finish reception of a packet.
@@ -246,6 +248,20 @@ class LoraPhy : public Object
     void SetDevice(Ptr<NetDevice> device);
 
     /**
+     * Get the sync word this PHY is configured to use.
+     *
+     * @return The configured sync word
+     */
+    uint8_t GetSyncWord() const;
+
+    /**
+     * Configure the PHY to use the given sync word.
+     *
+     * @param syncWord The sync word to use.
+     */
+    void SetSyncWord(uint8_t syncWord);
+
+    /**
      * Compute the symbol time from spreading factor and bandwidth.
      *
      * @param txParams The parameters for transmission.
@@ -278,6 +294,13 @@ class LoraPhy : public Object
     virtual void TxFinished(Ptr<const Packet> packet) = 0;
 
     Ptr<MobilityModel> m_mobility; //!< The mobility model associated to this PHY.
+
+    /**
+     * The sync word is used in the preamble. All outgoing packets will use
+     * this sync word and the PHY will not sync with incoming packets with
+     * a different sync word.
+     */
+    uint8_t m_syncWord;
 
   protected:
     // Member objects
@@ -322,6 +345,12 @@ class LoraPhy : public Object
      * of interference.
      */
     TracedCallback<Ptr<const Packet>, uint32_t> m_interferedPacket;
+
+    /**
+     * The trace source fired when a packet cannot be correctly received because
+     * received packet uses a different sync word than the PHY is configured.
+     */
+    TracedCallback<Ptr<const Packet>, uint32_t> m_wrongSyncWord;
 
     // Callbacks
 

--- a/model/lora-tag.cc
+++ b/model/lora-tag.cc
@@ -18,6 +18,8 @@ namespace lorawan
 
 NS_OBJECT_ENSURE_REGISTERED(LoraTag);
 
+const uint8_t LoraTag::SYNC_WORD_LORAWAN = 0x34;
+
 TypeId
 LoraTag::GetTypeId()
 {
@@ -34,10 +36,10 @@ LoraTag::GetInstanceTypeId() const
 
 LoraTag::LoraTag(uint8_t sf, uint8_t destroyedBy)
     : m_sf(sf),
+      m_sync(SYNC_WORD_LORAWAN),
       m_destroyedBy(destroyedBy),
       m_receivePower(0),
-      m_dataRate(0),
-      m_frequencyHz(0)
+      m_dataRate(0)
 {
 }
 
@@ -48,15 +50,17 @@ LoraTag::~LoraTag()
 uint32_t
 LoraTag::GetSerializedSize() const
 {
-    // Each datum about a spreading factor is 1 byte + receivePower (the size of a double) +
-    // frequency (4 bytes)
-    return 3 + sizeof(double) + 4;
+    // 4 * uint8_t: (m_sf, m_sync, m_destroyedBy, m_dataRate)
+    // 1 * uint32_t: (m_frequencyHz)
+    // 1 * double: (m_receivePower)
+    return 4 * sizeof(uint8_t) + 1 * sizeof(uint32_t) + 1 * sizeof(double);
 }
 
 void
 LoraTag::Serialize(TagBuffer i) const
 {
     i.WriteU8(m_sf);
+    i.WriteU8(m_sync);
     i.WriteU8(m_destroyedBy);
     i.WriteDouble(m_receivePower);
     i.WriteU8(m_dataRate);
@@ -67,6 +71,7 @@ void
 LoraTag::Deserialize(TagBuffer i)
 {
     m_sf = i.ReadU8();
+    m_sync = i.ReadU8();
     m_destroyedBy = i.ReadU8();
     m_receivePower = i.ReadDouble();
     m_dataRate = i.ReadU8();
@@ -125,6 +130,18 @@ uint32_t
 LoraTag::GetFrequency() const
 {
     return m_frequencyHz;
+}
+
+void
+LoraTag::SetSyncWord(uint8_t syncWord)
+{
+    m_sync = syncWord;
+}
+
+uint8_t
+LoraTag::GetSyncWord() const
+{
+    return m_sync;
 }
 
 uint8_t

--- a/model/lora-tag.h
+++ b/model/lora-tag.h
@@ -25,6 +25,8 @@ namespace lorawan
 class LoraTag : public Tag
 {
   public:
+    static const uint8_t SYNC_WORD_LORAWAN; //!< The sync word used in public LoRaWAN
+
     /**
      *  Register this type.
      *  @return The object TypeId.
@@ -129,8 +131,23 @@ class LoraTag : public Tag
      */
     void SetDataRate(uint8_t dataRate);
 
+    /**
+     * Set the sync word of this packet.
+     *
+     * @param syncWord The sync word to set
+     */
+    void SetSyncWord(uint8_t syncWord);
+
+    /**
+     * Get the sync word of this packet.
+     *
+     * @return The sync word of this packet
+     */
+    uint8_t GetSyncWord() const;
+
   private:
     uint8_t m_sf;           //!< The Spreading Factor used by the packet.
+    uint8_t m_sync;         //!< The sync word of this packet.
     uint8_t m_destroyedBy;  //!< The Spreading Factor that destroyed the packet.
     double m_receivePower;  //!< The reception power of this packet.
     uint8_t m_dataRate;     //!< The data rate that needs to be used to send this packet.

--- a/model/simple-end-device-lora-phy.cc
+++ b/model/simple-end-device-lora-phy.cc
@@ -72,11 +72,13 @@ SimpleEndDeviceLoraPhy::Send(Ptr<Packet> packet,
     LoraTag tag;
     packet->RemovePacketTag(tag);
     tag.SetSpreadingFactor(txParams.sf);
+    tag.SetSyncWord(GetSyncWord());
+    tag.SetFrequency(frequencyHz);
     packet->AddPacketTag(tag);
 
     // Send the packet over the channel
     NS_LOG_INFO("Sending the packet in the channel");
-    m_channel->Send(this, packet, txPowerDbm, txParams, duration, frequencyHz);
+    m_channel->Send(this, packet, txPowerDbm, txParams, duration, frequencyHz, GetSyncWord());
 
     // Schedule a call to signal the transmission end.
     Simulator::Schedule(duration, &SimpleEndDeviceLoraPhy::TxFinished, this, packet);
@@ -97,7 +99,8 @@ SimpleEndDeviceLoraPhy::StartReceive(Ptr<Packet> packet,
                                      double rxPowerDbm,
                                      uint8_t sf,
                                      Time duration,
-                                     uint32_t frequencyHz)
+                                     uint32_t frequencyHz,
+                                     uint8_t syncWord)
 {
     NS_LOG_FUNCTION(this << packet << rxPowerDbm << unsigned(sf) << duration << frequencyHz);
 
@@ -203,6 +206,12 @@ SimpleEndDeviceLoraPhy::StartReceive(Ptr<Packet> packet,
                 m_underSensitivity(packet, 0);
             }
 
+            canLockOnPacket = false;
+        }
+
+        if (syncWord != GetSyncWord())
+        {
+            m_wrongSyncWord(packet, m_device ? m_device->GetNode()->GetId() : 0);
             canLockOnPacket = false;
         }
 

--- a/model/simple-end-device-lora-phy.h
+++ b/model/simple-end-device-lora-phy.h
@@ -48,7 +48,8 @@ class SimpleEndDeviceLoraPhy : public EndDeviceLoraPhy
                       double rxPowerDbm,
                       uint8_t sf,
                       Time duration,
-                      uint32_t frequencyHz) override;
+                      uint32_t frequencyHz,
+                      uint8_t syncWord) override;
 
     // Implementation of LoraPhy's pure virtual functions
     void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) override;

--- a/model/simple-gateway-lora-phy.cc
+++ b/model/simple-gateway-lora-phy.cc
@@ -90,7 +90,7 @@ SimpleGatewayLoraPhy::Send(Ptr<Packet> packet,
     }
 
     // Send the packet in the channel
-    m_channel->Send(this, packet, txPowerDbm, txParams, duration, frequencyHz);
+    m_channel->Send(this, packet, txPowerDbm, txParams, duration, frequencyHz, GetSyncWord());
 
     Simulator::Schedule(duration, &SimpleGatewayLoraPhy::TxFinished, this, packet);
 
@@ -112,7 +112,8 @@ SimpleGatewayLoraPhy::StartReceive(Ptr<Packet> packet,
                                    double rxPowerDbm,
                                    uint8_t sf,
                                    Time duration,
-                                   uint32_t frequencyHz)
+                                   uint32_t frequencyHz,
+                                   uint8_t syncWord)
 {
     NS_LOG_FUNCTION(this << packet << rxPowerDbm << duration << frequencyHz);
 
@@ -178,23 +179,32 @@ SimpleGatewayLoraPhy::StartReceive(Ptr<Packet> packet,
                 // search for another ReceivePath
                 return;
             }
-            else // We have sufficient sensitivity to start receiving
+
+            if (syncWord != GetSyncWord())
             {
-                NS_LOG_INFO("Scheduling reception of a packet, occupying one demodulator");
-
-                // Block this resource
-                currentPath->LockOnEvent(event);
-                m_occupiedReceptionPaths++;
-
-                // Schedule the end of the reception of the packet
-                EventId endReceiveEventId =
-                    Simulator::Schedule(duration, &LoraPhy::EndReceive, this, packet, event);
-
-                currentPath->SetEndReceive(endReceiveEventId);
-
-                // Make sure we don't go on searching for other ReceivePaths
+                NS_LOG_INFO("Cannot lock on packet due to sync word mismatch");
+                m_wrongSyncWord(packet, m_device->GetNode()->GetId());
+                // The model matches the behavior of real hardware to only
+                // support one sync word at a time: Any other ReceivePath will
+                // also use the same sync word and fail to lock on.
                 return;
             }
+
+            // We have sufficient sensitivity to start receiving
+            NS_LOG_INFO("Scheduling reception of a packet, occupying one demodulator");
+
+            // Block this resource
+            currentPath->LockOnEvent(event);
+            m_occupiedReceptionPaths++;
+
+            // Schedule the end of the reception of the packet
+            EventId endReceiveEventId =
+                Simulator::Schedule(duration, &LoraPhy::EndReceive, this, packet, event);
+
+            currentPath->SetEndReceive(endReceiveEventId);
+
+            // Make sure we don't go on searching for other ReceivePaths
+            return;
         }
     }
     // If we get to this point, there are no demodulators we can use
@@ -276,6 +286,7 @@ SimpleGatewayLoraPhy::EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper:
             packet->RemovePacketTag(tag);
             tag.SetReceivePower(event->GetRxPowerdBm());
             tag.SetFrequency(event->GetFrequency());
+            tag.SetSyncWord(GetSyncWord());
             packet->AddPacketTag(tag);
 
             m_rxOkCallback(packet);

--- a/model/simple-gateway-lora-phy.h
+++ b/model/simple-gateway-lora-phy.h
@@ -48,7 +48,8 @@ class SimpleGatewayLoraPhy : public GatewayLoraPhy
                       double rxPowerDbm,
                       uint8_t sf,
                       Time duration,
-                      uint32_t frequencyHz) override;
+                      uint32_t frequencyHz,
+                      uint8_t syncWord) override;
 
     void EndReceive(Ptr<Packet> packet, Ptr<LoraInterferenceHelper::Event> event) override;
 

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -1142,6 +1142,14 @@ class PhyConnectivityTest : public TestCase
     void WrongSf(Ptr<const Packet> packet, uint32_t node);
 
     /**
+     * Callback for tracing LostPacketBecauseSyncWordMismatch.
+     *
+     * @param packet The packet lost.
+     * @param node The receiver node id if any, 0 otherwise.
+     */
+    void WrongSyncWord(Ptr<const Packet> packet, uint32_t node);
+
+    /**
      * Compare two packets to check if they are equal.
      *
      * @param packet1 A first packet.
@@ -1165,6 +1173,7 @@ class PhyConnectivityTest : public TestCase
     int m_interferenceCalls = 0;        //!< Counter for LostPacketBecauseInterference calls
     int m_wrongSfCalls = 0;             //!< Counter for LostPacketBecauseWrongSpreadingFactor calls
     int m_wrongFrequencyCalls = 0;      //!< Counter for LostPacketBecauseWrongFrequency calls
+    int m_wrongSyncWordCalls = 0;       //!< Counter for LostPacketBecauseSyncWordMismatch calls
 };
 
 // Add some help text to this case to describe what it is intended to test
@@ -1213,6 +1222,14 @@ PhyConnectivityTest::WrongSf(Ptr<const Packet> packet, uint32_t node)
 }
 
 void
+PhyConnectivityTest::WrongSyncWord(Ptr<const Packet> packet, uint32_t node)
+{
+    NS_LOG_FUNCTION(packet << node);
+
+    m_wrongSyncWordCalls++;
+}
+
+void
 PhyConnectivityTest::WrongFrequency(Ptr<const Packet> packet, uint32_t node)
 {
     NS_LOG_FUNCTION(packet << node);
@@ -1234,6 +1251,7 @@ PhyConnectivityTest::Reset()
     m_interferenceCalls = 0;
     m_wrongSfCalls = 0;
     m_wrongFrequencyCalls = 0;
+    m_wrongSyncWordCalls = 0;
 
     Ptr<LogDistancePropagationLossModel> loss = CreateObject<LogDistancePropagationLossModel>();
     loss->SetPathLossExponent(3.76);
@@ -1321,6 +1339,13 @@ PhyConnectivityTest::Reset()
                                        MakeCallback(&PhyConnectivityTest::WrongSf, this));
     edPhy3->TraceConnectWithoutContext("LostPacketBecauseWrongSpreadingFactor",
                                        MakeCallback(&PhyConnectivityTest::WrongSf, this));
+
+    edPhy1->TraceConnectWithoutContext("LostPacketBecauseSyncWordMismatch",
+                                       MakeCallback(&PhyConnectivityTest::WrongSyncWord, this));
+    edPhy2->TraceConnectWithoutContext("LostPacketBecauseSyncWordMismatch",
+                                       MakeCallback(&PhyConnectivityTest::WrongSyncWord, this));
+    edPhy3->TraceConnectWithoutContext("LostPacketBecauseSyncWordMismatch",
+                                       MakeCallback(&PhyConnectivityTest::WrongSyncWord, this));
 }
 
 // This method is the pure virtual method from class TestCase that every
@@ -1554,6 +1579,34 @@ PhyConnectivityTest::DoRun()
     NS_TEST_EXPECT_MSG_EQ(edPhy2->GetState(),
                           SimpleEndDeviceLoraPhy::STANDBY,
                           "State didn't switch to STANDBY as expected");
+
+    Reset();
+
+    // Not locking onto packet when sync word mismatches
+    ////////////////////////////////////////////////////
+
+    txParams.sf = 12;
+    edPhy3->SetSyncWord(0x42);
+    Simulator::Schedule(Seconds(2),
+                        &SimpleEndDeviceLoraPhy::Send,
+                        edPhy1,
+                        packet,
+                        txParams,
+                        868100000,
+                        14);
+
+    Simulator::Stop(Hours(2));
+    Simulator::Run();
+    Simulator::Destroy();
+
+    NS_TEST_EXPECT_MSG_EQ(m_receivedPacketCalls,
+                          1,
+                          "One PHY should have received the packet"); // One PHY
+
+    NS_TEST_EXPECT_MSG_EQ(
+        m_wrongSyncWordCalls,
+        1,
+        "One PHY should have lost the packet due to sync word mismatch"); // One PHY
 }
 
 /**
@@ -1817,7 +1870,7 @@ MacCommandTest::DoRun()
     { // WARNING: default values are manually set here
         uint8_t dataRate = 1;
         uint8_t txPower = 7;
-        uint16_t chMask = 0b1000; // enable only non-exisitng channel
+        uint16_t chMask = 0b1000; // enable only non-existing channel
         uint8_t chMaskCntl = 0;
         uint8_t nbTrans = 3;
         auto answers = RunMacCommand<LinkAdrReq>(dataRate, txPower, chMask, chMaskCntl, nbTrans);

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -2040,6 +2040,88 @@ MacCommandTest::DoRun()
 /**
  * @ingroup lorawan
  *
+ * It tests that LoraTag correctly serializes and deserilizes
+ */
+class LoraTagTest : public TestCase
+{
+  public:
+    LoraTagTest();           //!< Default constructor
+    ~LoraTagTest() override; //!< Destructor
+
+  private:
+    void DoRun() override;
+};
+
+// Add some help text to this case to describe what it is intended to test
+LoraTagTest::LoraTagTest()
+    : TestCase("Verify that LoraTag works as expected")
+{
+}
+
+// Reminder that the test case should clean up after itself
+LoraTagTest::~LoraTagTest()
+{
+}
+
+void
+LoraTagTest::DoRun()
+{
+    const uint32_t freq = 868100000;
+    const uint8_t destroyedBy = 42;
+    const uint8_t dataRate = 3;
+    const double receivePower = -122;
+    const uint8_t spreadingFactor = 9;
+
+    // Test constants are correctly:
+    NS_TEST_EXPECT_MSG_EQ(LoraTag::SYNC_WORD_LORAWAN,
+                          0x34,
+                          "Sync word 0x34 is used in the public LoRaWAN");
+
+    // Check that default parameters make sense
+    LoraTag tag(spreadingFactor, destroyedBy);
+    NS_TEST_EXPECT_MSG_EQ(tag.GetSyncWord(),
+                          LoraTag::SYNC_WORD_LORAWAN,
+                          "Default sync word should be suitable to join the public LoRaWAN");
+    NS_TEST_EXPECT_MSG_EQ(tag.GetSpreadingFactor(),
+                          spreadingFactor,
+                          "Spreading factor not initialized correctly");
+    NS_TEST_EXPECT_MSG_EQ(tag.GetDestroyedBy(),
+                          destroyedBy,
+                          "DestroyedBy not initialized correctly");
+
+    tag.SetFrequency(freq);
+    tag.SetDataRate(dataRate);
+    tag.SetReceivePower(receivePower);
+    tag.SetSpreadingFactor(spreadingFactor);
+
+    Packet pkt;
+    pkt.AddPacketTag(tag);
+
+    LoraTag tag2;
+    NS_TEST_ASSERT_MSG_EQ(pkt.RemovePacketTag(tag2), true, "Failed to deserialized LoraTag");
+    NS_TEST_EXPECT_MSG_EQ(tag.GetFrequency(),
+                          freq,
+                          "Frequency not correctly serialized/deserialized");
+    NS_TEST_EXPECT_MSG_EQ(tag.GetDestroyedBy(),
+                          destroyedBy,
+                          "DestroyedBy not correctly serialized/deserialized");
+    NS_TEST_EXPECT_MSG_EQ(tag.GetDataRate(),
+                          dataRate,
+                          "DataRate not correctly serialized/deserialized");
+    NS_TEST_EXPECT_MSG_EQ(tag.GetReceivePower(),
+                          receivePower,
+                          "ReceivePower not correctly serialized/deserialized");
+    NS_TEST_EXPECT_MSG_EQ(tag.GetSpreadingFactor(),
+                          spreadingFactor,
+                          "SpreadingFactor not correctly serialized/deserialized");
+    NS_TEST_EXPECT_MSG_EQ(tag.GetSyncWord(),
+                          LoraTag::SYNC_WORD_LORAWAN,
+                          "SpreadingFactor not correctly serialized/deserialized");
+}
+
+/**
+ * @ingroup lorawan
+ *
  * The TestSuite class names the TestSuite, identifies what type of TestSuite, and enables the
  * TestCases to be run. Typically, only the constructor for this class must be defined
  */
@@ -2073,6 +2155,7 @@ LorawanTestSuite::LorawanTestSuite()
     AddTestCase(new TimeOnAirTest, Duration::QUICK);
     AddTestCase(new PhyConnectivityTest, Duration::QUICK);
     AddTestCase(new MacCommandTest, Duration::QUICK);
+    AddTestCase(new LoraTagTest, Duration::QUICK);
 }
 
 // Do not forget to allocate an instance of this TestSuite

--- a/test/lorawan-test-suite.cc
+++ b/test/lorawan-test-suite.cc
@@ -1018,7 +1018,7 @@ TimeOnAirTest::DoRun()
     LoraTxParameters txParams;
     txParams.sf = 7;
     txParams.headerDisabled = false;
-    txParams.codingRate = 1;
+    txParams.codingRate = LoraTxParameters::CODING_RATE_4_5;
     txParams.bandwidthHz = 125000;
     txParams.nPreamble = 8;
     txParams.crcEnabled = true;
@@ -1035,7 +1035,7 @@ TimeOnAirTest::DoRun()
     duration = LoraPhy::GetOnAirTime(packet, txParams);
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 0.072192, 0.0001, "Unexpected duration");
 
-    txParams.codingRate = 2;
+    txParams.codingRate = LoraTxParameters::CODING_RATE_4_6;
     duration = LoraPhy::GetOnAirTime(packet, txParams);
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 0.078336, 0.0001, "Unexpected duration");
 
@@ -1079,7 +1079,7 @@ TimeOnAirTest::DoRun()
     duration = LoraPhy::GetOnAirTime(packet, txParams);
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 2.629632, 0.0001, "Unexpected duration");
 
-    txParams.codingRate = 1;
+    txParams.codingRate = LoraTxParameters::CODING_RATE_4_5;
     duration = LoraPhy::GetOnAirTime(packet, txParams);
     NS_TEST_EXPECT_MSG_EQ_TOL(duration.GetSeconds(), 2.301952, 0.0001, "Unexpected duration");
 }


### PR DESCRIPTION
> [!NOTE]
> This PR includes https://github.com/signetlabdei/lorawan/pull/203, it should be rebased once https://github.com/signetlabdei/lorawan/pull/203 is merged

## Proposed Changes

  - Extend `LoraTag` and `LoraChannelParameters` to carry the sync word
  - Extended `LoraPhy` to allow configuring the sync word
  - Extended `LoraPhy` with a `"LostPacketBecauseSyncWordMismatch"` trace source
  - Extended `SimpleGatewayLoraPhy` and `SimpleEndDeviceLoraPhy` to not receive incoming packets when the don't match the configured sync word
  - Added a test that on mismatching sync word the packet is indeed lost and `"LostPacketBecauseSyncWordMismatch"` is called
