### PR TITLE
[CI] Mitigate codecov pedantry

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 5%
+    patch:
+      default:
+        target: 50%


### PR DESCRIPTION
This pull request add a codecov.yml file with custom settings for code coverage checks. Codecov now should only notify failure if a PR (or single direct repo commit) lowers the global test coverage by >5% or it does not have coverage on at least 50% of the specific code changes introduced.